### PR TITLE
[FIX] -- admin site queue choices now use user-defined settings instead of hardcoded values.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.3.5 🌈
+
+### Bug Fixes
+
+- Fixes issue where admin queue choices were hardcoded by loading them dynamically from user-defined settings like `settings.SCHEDULER_QUEUES`. @DhavalGojiya #278
+
 ## v1.3.4 🌈
 
 ### 🧰 Maintenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "django-tasks-scheduler"
 packages = [
     { include = "scheduler" },
 ]
-version = "1.3.4"
+version = "1.3.5"
 description = "An async job scheduler for django using redis"
 readme = "README.md"
 keywords = ["redis", "django", "background-jobs", "job-queue", "task-queue", "redis-queue", "scheduled-jobs"]


### PR DESCRIPTION
**Fixes:** [Issue #278](https://github.com/django-commons/django-tasks-scheduler/issues/278)

This PR resolves a bug present in versions `v1.3.3` and `v1.3.4` of `django-tasks-scheduler`.

### 🛠️ What’s Fixed

The queue choices in the Django admin task creation form are now loaded **dynamically** from user-defined settings (`RQ_QUEUES` or `SCHEDULER_QUEUES`), instead of using hardcoded values like `"default"`, `"low"`, and `"high"`.

---

### ✅ Working Screenshot

You can view the fix at:  
`/admin/scheduler/crontask/add/` 
`/admin/scheduler/repeatabletask/add/`
`/admin/scheduler/scheduledtask/add/`

![Queue Choices Screenshot](https://github.com/user-attachments/assets/3cb55350-a0e3-4b46-a335-79861fea48df)

---

### ⚠️ Validation Behavior

If a user attempts to submit a value that isn’t defined in their settings, a validation error will appear.  
![Validation Error Screenshot](https://github.com/user-attachments/assets/5037089a-94da-4547-b496-62415f1d8916)

---

### 🧪 Queue Execution Confirmation

The task scheduled under the `"alerts"` queue was successfully picked up and executed by the respective worker, confirming that dynamic queue selection is functioning as expected.
![Worker Run Success](https://github.com/user-attachments/assets/65ac88c9-8881-4ea8-9045-f15b88fda05e)

---

### 📌 What’s Next After This PR Is Merged

- [x] Update `pyproject.toml` version (e.g. `1.3.5`) and update `README.md` if necessary
- [ ] Create a new GitHub tag: `v1.3.5`
- [ ] Publish a new PyPI release for `v1.3.5`