### PR TITLE
[FIX] -- mkdocs repo links to correct GitHub organization.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_author: Daniel Moran
 site_description: >-
   Documentation for django-tasks-scheduler django library
 # Repository
-repo_name: dsoftwareinc/django-tasks-scheduler
+repo_name: django-commons/django-tasks-scheduler
 repo_url: https://github.com/django-commons/django-tasks-scheduler
 
 # Copyright
@@ -38,7 +38,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.magiclink:
       repo_url_shorthand: true
-      user: dsoftware-inc
+      user: django-commons
       repo: django-tasks-scheduler
   - pymdownx.mark
   - pymdownx.smartsymbols


### PR DESCRIPTION
**Fixes broken GitHub links in documentation**

This PR updates the MkDocs configuration to point to the correct GitHub organization and repository.

---

### 🐞 What’s the issue?

Currently, issue and PR links in the documentation (e.g. changelog) incorrectly point to:

```
https://github.com/dsoftware-inc/django-tasks-scheduler
```

Instead of the correct repo:

```
https://github.com/django-commons/django-tasks-scheduler
```

This causes links like `#273` to open under the wrong user/org, resulting in 404 errors.

🔗 You can see this in action on the public changelog here:  
[https://django-tasks-scheduler.readthedocs.io/en/stable/changelog/](https://django-tasks-scheduler.readthedocs.io/en/stable/changelog/)

---

### 🔧 What this PR changes

- Updates `repo_name` and `user` in `mkdocs.yml` from `dsoftware-inc` → `django-commons`
- Ensures all shorthand issue and PR links generate URLs pointing to the correct repository
- Fixes broken links in the rendered documentation (e.g. changelog)

---

### 📸 Before (Broken Links)

![django-tasks-scheduler-mkdocs-broken-link-ss-dhaval](https://github.com/user-attachments/assets/7c957cb4-15fd-484d-a857-f4e98f174521)

---

### ✅ After (Fixed Links)

After this PR, clicking an issue reference like `#273` will correctly open:

```
https://github.com/django-commons/django-tasks-scheduler/issues/273
```

---

### 📌 Next Steps

- [ ] Merge this PR
- [ ] Rebuild and deploy updated documentation via ReadTheDocs

Thanks!