### PR TITLE
[FEAT] - Add CI check to validate 'uv.lock' is up-to-date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  uv-lock-check:
+    runs-on: ubuntu-latest
+    name: "UV Lockfile Sync Validation 🔒"
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Check uv.lock sync status
+        run: uv lock --locked
+
   ruff:
     runs-on: ubuntu-latest
     name: "ruff on code"
@@ -26,7 +43,7 @@ jobs:
           src: "."
 
   test-regular:
-    needs: ["ruff"]
+    needs: ["ruff", "uv-lock-check"]
     runs-on: ubuntu-latest
     name: "Tests py${{ matrix.python-version }}/dj${{ matrix.django-version }}/${{ matrix.broker }}"
     strategy:


### PR DESCRIPTION
## Summary

This PR adds a **GitHub Actions job** to validate the `uv.lock` file and ensure it is consistent with `pyproject.toml`

## Changes

* Added a new job: **`UV Lockfile Sync Validation 🔒`**

  * Checks `uv.lock` consistency using `uv lock --locked`
* Ensures that CI fails if the lockfile is out of sync.

## Benefits

* Prevents **out-of-sync dependencies** from entering the codebase.
* Improves **CI reliability** by catching lockfile issues early.
* Maintains **consistent environment** across all contributors and CI runners.

## How to Test / Verify

1. Push changes to a branch with an **outdated `uv.lock`**.
2. Observe that the CI **fails the lockfile check**.
3. Update the lockfile with `uv lock` and verify that CI passes.