### PR TITLE
Add Python 3.14 to the CI workflow matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13",  "3.14"]
         django-version: ["5.2.5"]
         broker: ["redis", "fakeredis", "valkey"]
         include:
@@ -76,6 +76,7 @@ jobs:
         with:
           cache-dependency-path: uv.lock
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
 
       - name: Install django version
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3
* https://docs.python.org/3.14/whatsnew/3.14.html
* https://code.djangoproject.com/ticket/35844
> Django 5.2 will be the first version to support Python 3.14