### PR TITLE
GitHub Actions: Turn off fail-fast so we can see all failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Tests py${{ matrix.python-version }}/dj${{ matrix.django-version }}/${{ matrix.broker }}"
     strategy:
+      fail-fast: false
       max-parallel: 6
       matrix:
         python-version: ["3.11", "3.12", "3.13"]


### PR DESCRIPTION
Some GitHub Actions tests are [currently failing](https://github.com/django-commons/django-tasks-scheduler/actions/runs/18165099756/job/51705194342?pr=301), so let's examine all errors.

`build: strategy: fail-fast: false`
* https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast