### PR TITLE
[FIX] - annotation handling for Python 3.14+ versions

### DIFF
--- a/scheduler/settings.py
+++ b/scheduler/settings.py
@@ -43,7 +43,10 @@ def conf_settings():
         return
     if not isinstance(user_settings, dict):
         raise ImproperlyConfigured("SCHEDULER_CONFIG should be a SchedulerConfiguration or dict")
-    annotations = get_annotations(SCHEDULER_CONFIG)
+
+    # Use `type(obj)` because Python 3.14+ `annotationlib.get_annotations()` works only on classes/functions/modules.
+    # It reads __annotations__ or __annotate__; instances without annotations will fail.
+    annotations = get_annotations(type(SCHEDULER_CONFIG))
     for k, v in user_settings.items():
         if k not in annotations:
             raise ImproperlyConfigured(f"Unknown setting {k} in SCHEDULER_CONFIG")


### PR DESCRIPTION
**Fixes:** [Issue #305](https://github.com/django-commons/django-tasks-scheduler/issues/305)

Now @cclauss can continue working on the existing open draft PR: [PR #306](https://github.com/django-commons/django-tasks-scheduler/pull/306) 
for the next changes needed to make this package compatible with `Python 3.14`
