### PR TITLE
fix(admin): handle None scheduled_time in TaskAdmin.next_run (#363)

### DIFF
--- a/scheduler/admin/task_admin.py
+++ b/scheduler/admin/task_admin.py
@@ -141,11 +141,13 @@ class TaskAdmin(admin.ModelAdmin):
     @admin.display(description="Next run")
     def next_run(self, o: Task) -> Union[str, datetime]:
         res = o.scheduled_time
+        if res is None:
+            return _("Not scheduled")
         if res < timezone.now():
             o.save(clean=False)
             res = o.scheduled_time
-        if res is None:
-            return _("Not scheduled")
+            if res is None:
+                return _("Not scheduled")
         if is_naive(res):
             res = timezone.make_aware(res, timezone.get_current_timezone())
         return res

--- a/scheduler/tests/test_task_admin_display.py
+++ b/scheduler/tests/test_task_admin_display.py
@@ -1,0 +1,21 @@
+from django.contrib import admin
+from django.test import TestCase
+
+from scheduler.admin.task_admin import TaskAdmin
+from scheduler.models import Task, TaskType
+from scheduler.tests.testtools import task_factory
+
+
+class TestTaskAdminNextRunDisplay(TestCase):
+    def setUp(self) -> None:
+        self.admin = TaskAdmin(Task, admin.site)
+
+    def test_next_run_returns_not_scheduled_when_scheduled_time_is_none(self) -> None:
+        # Regression: TypeError when scheduled_time is None (issue #363)
+        task = task_factory(TaskType.CRON, enabled=False)
+        task.scheduled_time = None
+        task.save(clean=False)
+
+        result = self.admin.next_run(task)
+
+        assert str(result) == "Not scheduled"


### PR DESCRIPTION
Fixes #363.

`TaskAdmin.next_run` compared `scheduled_time` to `timezone.now()` before the `None` check, raising `TypeError` on the Tasks admin list page whenever any task had `scheduled_time = None` (e.g. a disabled task). The reporter pointed out the inverted condition in [task_admin.py:141-151](https://github.com/django-commons/django-tasks-scheduler/blob/v4.0.8/scheduler/admin/task_admin.py#L141-L151).

Move the `None` check before the comparison and re-check after `o.save(clean=False)` (which can leave `scheduled_time` as `None` for non-schedulable types). Added a regression test in `scheduler/tests/test_task_admin_display.py`.