### PR TITLE
fix(admin): handle None scheduled_time in TaskAdmin.next_run

### DIFF
--- a/scheduler/admin/task_admin.py
+++ b/scheduler/admin/task_admin.py
@@ -141,11 +141,13 @@ class TaskAdmin(admin.ModelAdmin):
     @admin.display(description="Next run")
     def next_run(self, o: Task) -> Union[str, datetime]:
         res = o.scheduled_time
+        if res is None:
+            return _("Not scheduled")
         if res < timezone.now():
             o.save(clean=False)
             res = o.scheduled_time
-        if res is None:
-            return _("Not scheduled")
+            if res is None:
+                return _("Not scheduled")
         if is_naive(res):
             res = timezone.make_aware(res, timezone.get_current_timezone())
         return res

--- a/scheduler/tests/test_task_admin.py
+++ b/scheduler/tests/test_task_admin.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+
+from django.contrib import admin
+from django.test import TestCase
+from django.utils import timezone
+
+from scheduler.admin.task_admin import TaskAdmin
+from scheduler.models import Task, TaskType
+
+
+class TestTaskAdminNextRun(TestCase):
+    def setUp(self) -> None:
+        self.admin = TaskAdmin(Task, admin.site)
+
+    def test_next_run_returns_not_scheduled_when_scheduled_time_is_none(self) -> None:
+        task = Task(
+            name="unscheduled task",
+            task_type=TaskType.ONCE.value,
+            queue="default",
+            callable="scheduler.tests.jobs.test_job",
+            enabled=False,
+            scheduled_time=None,
+        )
+
+        # Regression for #363: comparison against timezone.now() must not run
+        # when scheduled_time is None, otherwise a TypeError is raised when the
+        # admin list view renders the column.
+        assert self.admin.next_run(task) == "Not scheduled"
+
+    def test_next_run_returns_datetime_for_future_scheduled_time(self) -> None:
+        future = timezone.now() + timedelta(days=1)
+        task = Task(
+            name="future task",
+            task_type=TaskType.ONCE.value,
+            queue="default",
+            callable="scheduler.tests.jobs.test_job",
+            enabled=True,
+            scheduled_time=future,
+        )
+
+        result = self.admin.next_run(task)
+
+        assert not isinstance(result, str)
+        assert result == future or result == timezone.make_aware(future, timezone.get_current_timezone())


### PR DESCRIPTION
Fixes #363.

The `next_run` column compares `scheduled_time` against `timezone.now()` before checking `is None`, so the admin task list crashes with `TypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'` whenever any task in the list has an unset `scheduled_time` (e.g. a disabled task).

Reorder the check so `None` is handled up-front and after the post-save refresh.

Added `scheduler/tests/test_task_admin.py` with a regression test that exercises both paths; it fails on master and passes with this change.