### PR TITLE
Fix TypeError on Task admin page when scheduled_time is None

### DIFF
--- a/scheduler/admin/task_admin.py
+++ b/scheduler/admin/task_admin.py
@@ -141,6 +141,8 @@ class TaskAdmin(admin.ModelAdmin):
     @admin.display(description="Next run")
     def next_run(self, o: Task) -> Union[str, datetime]:
         res = o.scheduled_time
+        if res is None:
+            return _("Not scheduled")
         if res < timezone.now():
             o.save(clean=False)
             res = o.scheduled_time

--- a/scheduler/tests/test_task_admin.py
+++ b/scheduler/tests/test_task_admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+
+from scheduler.admin.task_admin import TaskAdmin
+from scheduler.models import Task, TaskType
+from scheduler.tests.testtools import SchedulerBaseCase, task_factory
+
+
+class TestTaskAdminNextRun(SchedulerBaseCase):
+    def setUp(self):
+        super().setUp()
+        self.admin = TaskAdmin(Task, admin.site)
+
+    def test_next_run_with_scheduled_time_none(self):
+        task = task_factory(TaskType.CRON)
+        task.scheduled_time = None
+        self.assertEqual(str(self.admin.next_run(task)), "Not scheduled")
+
+    def test_next_run_with_scheduled_time_set(self):
+        task = task_factory(TaskType.ONCE)
+        self.assertEqual(self.admin.next_run(task), task.scheduled_time)


### PR DESCRIPTION
Fixes #363.

`TaskAdmin.next_run` compared `scheduled_time` against `timezone.now()` before checking for `None`, raising `TypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime'` when listing tasks with no scheduled time. The `None` check is now done first, returning "Not scheduled".

Added regression tests in `scheduler/tests/test_task_admin.py`.