### PR TITLE
chore(ci): fix CI pipeline security issues reported by zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,6 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -16,20 +16,27 @@ jobs:
       name: pypi
       url: https://pypi.org/p/fakeredis
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.14"
+          version: "0.11.21"
+          enable-cache: false
+
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
       - name: Publish documentation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,12 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v6
+    - name: Checkout the repository
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.13"
     - name: Install pypa/build
@@ -74,6 +75,7 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+
     - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@v1.13.0
       with:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -34,13 +34,21 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+
       - name: print all inputs
+        env:
+          GITHUB_EVENT_INPUTS_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          GITHUB_EVENT_INPUTS_REASON: ${{ github.event.inputs.reason }}
+          GITHUB_EVENT_INPUTS_ENVIRONMENT_OPTIONAL: ${{ github.event.inputs.environment-optional }}
+          GITHUB_EVENT_INPUTS_CHOICES_INPUT_OPTIONAL: ${{ github.event.inputs.choices-input-optional }}
+          GITHUB_EVENT_INPUTS_NUMBER_INPUT_OPTIONAL: ${{ github.event.inputs.number-input-optional }}
         run: |
-          echo "environment: ${{ github.event.inputs.environment }}"
-          echo "reason: ${{ github.event.inputs.reason }}"
-          echo "environment-optional: ${{ github.event.inputs.environment-optional }}"
-          echo "choices-input-optional: ${{ github.event.inputs.choices-input-optional }}"
-          echo "number-input-optional: ${{ github.event.inputs.number-input-optional }}"
+          echo "environment: ${GITHUB_EVENT_INPUTS_ENVIRONMENT}"
+          echo "reason: ${GITHUB_EVENT_INPUTS_REASON}"
+          echo "environment-optional: ${GITHUB_EVENT_INPUTS_ENVIRONMENT_OPTIONAL}"
+          echo "choices-input-optional: ${GITHUB_EVENT_INPUTS_CHOICES_INPUT_OPTIONAL}"
+          echo "number-input-optional: ${GITHUB_EVENT_INPUTS_NUMBER_INPUT_OPTIONAL}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,16 +63,18 @@ jobs:
       version: ${{ steps.getVersion.outputs.VERSION }}
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          version: "0.11.14"
+          version: "0.11.21"
 
-      - uses: actions/setup-python@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           cache-dependency-path: uv.lock
           python-version: "${{ matrix.python-version }}"


### PR DESCRIPTION
## Description

Fixes CI pipeline security issues reported by [zizmor](https://docs.zizmor.sh/)

<details>
<summary>zizmor output (before)</summary>

```code
dhaval@lg-ubuntu:~/Open-Source/django-tasks-scheduler$ uvx zizmor .

 INFO zizmor: 🌈 zizmor v1.25.0
 INFO audit: zizmor: 🌈 completed ./.github/actions/test-coverage/action.yml
 INFO audit: zizmor: 🌈 completed ./.github/dependabot.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish-documentation.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test-workflow.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> ./.github/dependabot.yml:8:5
  |
8 |   - package-ecosystem: "pip"
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ missing cooldown configuration
  |
  = note: audit confidence → High
  = note: this finding has an auto-fix

error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> ./.github/workflows/publish-documentation.yml:26:9
   |
 5 | / on:
 6 | |   release:
 7 | |     types: [published]
 8 | |   workflow_dispatch:
   | |____________________- generally used when publishing artifacts generated at runtime
...
26 |         - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ enables caching by default
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/test-workflow.yml:42:34
   |
41 |         run: |
   |         --- this run block
42 |           echo "environment: ${{ github.event.inputs.environment }}"
   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/test-workflow.yml:43:29
   |
41 |         run: |
   |         --- this run block
42 |           echo "environment: ${{ github.event.inputs.environment }}"
43 |           echo "reason: ${{ github.event.inputs.reason }}"
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/test-workflow.yml:44:43
   |
41 |         run: |
   |         --- this run block
...
44 |           echo "environment-optional: ${{ github.event.inputs.environment-optional }}"
   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/test-workflow.yml:45:45
   |
41 |         run: |
   |         --- this run block
...
45 |           echo "choices-input-optional: ${{ github.event.inputs.choices-input-optional }}"
   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/test-workflow.yml:46:44
   |
41 |         run: |
   |         --- this run block
...
46 |           echo "number-input-optional: ${{ github.event.inputs.number-input-optional }}"
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

30 findings (2 ignored, 21 suppressed, 1 safe fixes, 6 unsafe fixes): 0 informational, 0 low, 1 medium, 6 high
```
</details>

<details>
<summary>zizmor output (After PR changes)</summary>

```code
dhaval@lg-ubuntu:~/Open-Source/django-tasks-scheduler$ uvx zizmor .
 INFO zizmor: 🌈 zizmor v1.25.0
 INFO audit: zizmor: 🌈 completed ./.github/actions/test-coverage/action.yml
 INFO audit: zizmor: 🌈 completed ./.github/dependabot.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish-documentation.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test-workflow.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/test.yml
No findings to report. Good job! (2 ignored, 21 suppressed)
```
</details>
