### PR TITLE
Adds a get_current_job() helper function that returns the current job within the job context

### DIFF
--- a/scheduler/tests/test_job_decorator.py
+++ b/scheduler/tests/test_job_decorator.py
@@ -9,7 +9,7 @@ from . import conf  # noqa
 from ..decorators import JOB_METHODS_LIST, job
 from ..redis_models import JobStatus
 from ..redis_models.job import JobModel
-from ..worker import create_worker
+from ..worker import create_worker, get_current_job
 
 
 @job()
@@ -55,12 +55,27 @@ def long_running_func():
     time.sleep(1000)
 
 
+@job()
+def test_knows_itself():
+    "when a job callable is called within a job context, get_current_job() returns the job itself"
+    job = get_current_job()
+    assert job is not None
+
+    job.meta["_my_key"] = job._key
+
+
+@job()
+def test_doesnt_know_itself():
+    "when a job callable is called directly, get_current_job() should return None"
+    assert get_current_job() is None
+
+
 class JobDecoratorTest(TestCase):
     def setUp(self) -> None:
         get_queue("default").connection.flushall()
 
     def test_all_job_methods_registered(self):
-        self.assertEqual(7, len(JOB_METHODS_LIST))
+        self.assertEqual(9, len(JOB_METHODS_LIST))
 
     def test_job_decorator_no_params(self):
         test_job.delay()
@@ -146,3 +161,24 @@ class JobDecoratorTest(TestCase):
         self.assertEqual(j.func, long_running_func)
         self.assertEqual(j.kwargs, {})
         self.assertEqual(j.status, JobStatus.FAILED)
+
+    def test_get_current_job(self):
+        queue_name = "default"
+        job_id = test_knows_itself.delay()._key
+        assert job_id is not None
+
+        worker = create_worker(queue_name, burst=True)
+        worker.work()
+
+        jobs_list = worker.queues[0].get_all_jobs()
+        self.assertEqual(1, len(jobs_list))
+        job = jobs_list[0]
+        self.assertEqual(job.func, test_knows_itself)
+        self.assertEqual(job.kwargs, {})
+        self.assertEqual(job.status, JobStatus.FINISHED)
+
+        assert job.meta["_my_key"] == job_id
+
+    def test_direct_call_to_job(self):
+        "Calling the job function directly, get_current_job() will return None"
+        test_doesnt_know_itself()

--- a/scheduler/tests/test_job_decorator.py
+++ b/scheduler/tests/test_job_decorator.py
@@ -177,7 +177,7 @@ class JobDecoratorTest(TestCase):
         self.assertEqual(job.kwargs, {})
         self.assertEqual(job.status, JobStatus.FINISHED)
 
-        assert job.meta["_my_key"] == job_id
+        self.assertEqual(job.meta["_my_key"], job_id)
 
     def test_direct_call_to_job(self):
         "Calling the job function directly, get_current_job() will return None"

--- a/scheduler/worker/__init__.py
+++ b/scheduler/worker/__init__.py
@@ -1,8 +1,4 @@
-__all__ = [
-    "Worker",
-    "create_worker",
-    "WorkerScheduler",
-]
+__all__ = ["Worker", "create_worker", "WorkerScheduler", "get_current_job"]
 
 from .scheduler import WorkerScheduler
-from .worker import Worker, create_worker
+from .worker import Worker, create_worker, get_current_job

--- a/scheduler/worker/local.py
+++ b/scheduler/worker/local.py
@@ -1,0 +1,432 @@
+# ruff: noqa: E731
+"""
+werkzeug.local
+~~~~~~~~~~~~~~
+
+This module implements context-local objects.
+
+:copyright: (c) 2011 by the Werkzeug Team, see AUTHORS for more details.
+:license: BSD, see LICENSE for more details.
+"""
+
+# Since each thread has its own greenlet we can just use those as identifiers
+# for the context.  If greenlets are not available we fall back to the
+# current thread ident.
+try:
+    from greenlet import getcurrent as get_ident
+except ImportError:
+    from threading import get_ident  # type: ignore[assignment]
+
+
+def release_local(local):
+    """Releases the contents of the local for the current context.
+    This makes it possible to use locals without a manager.
+
+    Example::
+
+        >>> loc = Local()
+        >>> loc.foo = 42
+        >>> release_local(loc)
+        >>> hasattr(loc, 'foo')
+        False
+
+    With this function one can release :class:`Local` objects as well
+    as :class:`StackLocal` objects.  However it is not possible to
+    release data held by proxies that way, one always has to retain
+    a reference to the underlying local object in order to be able
+    to release it.
+
+    .. versionadded:: 0.6.1
+    """
+    local.__release_local__()
+
+
+class Local:
+    __slots__ = ("__storage__", "__ident_func__")
+
+    def __init__(self):
+        object.__setattr__(self, "__storage__", {})
+        object.__setattr__(self, "__ident_func__", get_ident)
+
+    def __iter__(self):
+        return iter(self.__storage__.items())
+
+    def __call__(self, proxy):
+        """Create a proxy for a name."""
+        return LocalProxy(self, proxy)
+
+    def __release_local__(self):
+        self.__storage__.pop(self.__ident_func__(), None)
+
+    def __getattr__(self, name):
+        try:
+            return self.__storage__[self.__ident_func__()][name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        ident = self.__ident_func__()
+        storage = self.__storage__
+        try:
+            storage[ident][name] = value
+        except KeyError:
+            storage[ident] = {name: value}
+
+    def __delattr__(self, name):
+        try:
+            del self.__storage__[self.__ident_func__()][name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+class LocalStack:
+    """This class works similar to a :class:`Local` but keeps a stack
+    of objects instead.  This is best explained with an example::
+
+        >>> ls = LocalStack()
+        >>> ls.push(42)
+        >>> ls.top
+        42
+        >>> ls.push(23)
+        >>> ls.top
+        23
+        >>> ls.pop()
+        23
+        >>> ls.top
+        42
+
+    They can be force released by using a :class:`LocalManager` or with
+    the :func:`release_local` function but the correct way is to pop the
+    item from the stack after using.  When the stack is empty it will
+    no longer be bound to the current context (and as such released).
+
+    By calling the stack without arguments it returns a proxy that resolves to
+    the topmost item on the stack.
+
+    .. versionadded:: 0.6.1
+    """
+
+    def __init__(self):
+        self._local = Local()
+
+    def __release_local__(self):
+        self._local.__release_local__()
+
+    def _get__ident_func__(self):
+        return self._local.__ident_func__
+
+    def _set__ident_func__(self, value):
+        object.__setattr__(self._local, "__ident_func__", value)
+
+    __ident_func__ = property(_get__ident_func__, _set__ident_func__)
+    del _get__ident_func__, _set__ident_func__
+
+    def __call__(self):
+        def _lookup():
+            rv = self.top
+            if rv is None:
+                raise RuntimeError("object unbound")
+            return rv
+
+        return LocalProxy(_lookup)
+
+    def push(self, obj):
+        """Pushes a new item to the stack"""
+        rv = getattr(self._local, "stack", None)
+        if rv is None:
+            self._local.stack = rv = []
+        rv.append(obj)
+        return rv
+
+    def pop(self):
+        """Removes the topmost item from the stack, will return the
+        old value or `None` if the stack was already empty.
+        """
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            return None
+        elif len(stack) == 1:
+            release_local(self._local)
+            return stack[-1]
+        else:
+            return stack.pop()
+
+    @property
+    def top(self):
+        """The topmost item on the stack.  If the stack is empty,
+        `None` is returned.
+        """
+        try:
+            return self._local.stack[-1]
+        except (AttributeError, IndexError):
+            return None
+
+    def __len__(self):
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            return 0
+        return len(stack)
+
+
+class LocalManager:
+    """Local objects cannot manage themselves. For that you need a local
+    manager.  You can pass a local manager multiple locals or add them later
+    by appending them to `manager.locals`.  Every time the manager cleans up
+    it, will clean up all the data left in the locals for this context.
+
+    The `ident_func` parameter can be added to override the default ident
+    function for the wrapped locals.
+
+    .. versionchanged:: 0.6.1
+       Instead of a manager the :func:`release_local` function can be used
+       as well.
+
+    .. versionchanged:: 0.7
+       `ident_func` was added.
+    """
+
+    def __init__(self, locals_=None, ident_func=None):
+        if locals_ is None:
+            self.locals = []
+        elif isinstance(locals_, Local):
+            self.locals = [locals]
+        else:
+            self.locals = list(locals_)
+        if ident_func is not None:
+            self.ident_func = ident_func
+            for local in self.locals:
+                object.__setattr__(local, "__ident_func__", ident_func)
+        else:
+            self.ident_func = get_ident
+
+    def get_ident(self):
+        """Return the context identifier the local objects use internally for
+        this context.  You cannot override this method to change the behavior
+        but use it to link other context local objects (such as SQLAlchemy's
+        scoped sessions) to the Werkzeug locals.
+
+        .. versionchanged:: 0.7
+           You can pass a different ident function to the local manager that
+           will then be propagated to all the locals passed to the
+           constructor.
+        """
+        return self.ident_func()
+
+    def cleanup(self):
+        """Manually clean up the data in the locals for this context.  Call
+        this at the end of the request or use `make_middleware()`.
+        """
+        for local in self.locals:
+            release_local(local)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} storages: {len(self.locals)}>"
+
+
+class LocalProxy:
+    """Acts as a proxy for a werkzeug local.  Forwards all operations to
+    a proxied object.  The only operations not supported for forwarding
+    are right handed operands and any kind of assignment.
+
+    Example usage::
+
+        from werkzeug.local import Local
+        l = Local()
+
+        # these are proxies
+        request = l('request')
+        user = l('user')
+
+
+        from werkzeug.local import LocalStack
+        _response_local = LocalStack()
+
+        # this is a proxy
+        response = _response_local()
+
+    Whenever something is bound to l.user / l.request the proxy objects
+    will forward all operations.  If no object is bound a :exc:`RuntimeError`
+    will be raised.
+
+    To create proxies to :class:`Local` or :class:`LocalStack` objects,
+    call the object as shown above.  If you want to have a proxy to an
+    object looked up by a function, you can (as of Werkzeug 0.6.1) pass
+    a function to the :class:`LocalProxy` constructor::
+
+        session = LocalProxy(lambda: get_current_request().session)
+
+    .. versionchanged:: 0.6.1
+       The class can be instantiated with a callable as well now.
+    """
+
+    __slots__ = ("__local", "__dict__", "__name__")
+
+    def __init__(self, local, name=None):
+        object.__setattr__(self, "_LocalProxy__local", local)
+        object.__setattr__(self, "__name__", name)
+
+    def _get_current_object(self):
+        """Return the current object.  This is useful if you want the real
+        object behind the proxy at a time for performance reasons or because
+        you want to pass the object into a different context.
+        """
+        if not hasattr(self.__local, "__release_local__"):
+            return self.__local()
+        try:
+            return getattr(self.__local, self.__name__)
+        except AttributeError:
+            raise RuntimeError(f"no object bound to {self.__name__}")
+
+    @property
+    def __dict__(self):
+        try:
+            return self._get_current_object().__dict__
+        except RuntimeError:
+            raise AttributeError("__dict__")
+
+    def __repr__(self):
+        try:
+            obj = self._get_current_object()
+        except RuntimeError:
+            return f"<{self.__class__.__name__} unbound>"
+        return repr(obj)
+
+    def __dir__(self):
+        try:
+            return dir(self._get_current_object())
+        except RuntimeError:
+            return []
+
+    def __getattr__(self, name):
+        if name == "__members__":
+            return dir(self._get_current_object())
+        return getattr(self._get_current_object(), name)
+
+    def __setitem__(self, key, value):
+        self._get_current_object()[key] = value
+
+    def __delitem__(self, key):
+        del self._get_current_object()[key]
+
+    def __setattr__(self, name, value):
+        setattr(self._get_current_object(), name, value)
+
+    def __delattr__(self, name):
+        return delattr(self._get_current_object(), name)
+
+    def __str__(self):
+        return str(self._get_current_object())
+
+    def __lt__(self, other):
+        return self._get_current_object() < other
+
+    def __le__(self, other):
+        return self._get_current_object() <= other
+
+    def __eq__(self, other):
+        return self._get_current_object() == other
+
+    def __ne__(self, other):
+        return self._get_current_object() != other
+
+    def __gt__(self, other):
+        return self._get_current_object() > other
+
+    def __ge__(self, other):
+        return self._get_current_object() >= other
+
+    def __hash__(self):
+        return hash(self._get_current_object())
+
+    def __call__(self, *args, **kwargs):
+        return self._get_current_object()(*args, **kwargs)
+
+    def __len__(self):
+        return len(self._get_current_object())
+
+    def __getitem__(self, i):
+        return self._get_current_object()[i]
+
+    def __iter__(self):
+        return iter(self._get_current_object())
+
+    def __contains__(self, obj):
+        return obj in self._get_current_object()
+
+    def __add__(self, other):
+        return self._get_current_object() + other
+
+    def __sub__(self, other):
+        return self._get_current_object() - other
+
+    def __mul__(self, other):
+        return self._get_current_object() * other
+
+    def __floordiv__(self, other):
+        return self._get_current_object() // other
+
+    def __mod__(self, other):
+        return self._get_current_object() % other
+
+    def __divmod__(self, other):
+        return self._get_current_object().__divmod__(other)
+
+    def __pow__(self, other):
+        return self._get_current_object() ** other
+
+    def __lshift__(self, other):
+        return self._get_current_object() << other
+
+    def __rshift__(self, other):
+        return self._get_current_object() >> other
+
+    def __and__(self, other):
+        return self._get_current_object() & other
+
+    def __xor__(self, other):
+        return self._get_current_object() ^ other
+
+    def __or__(self, other):
+        return self._get_current_object() | other
+
+    def __div__(self, other):
+        return self._get_current_object().__div__(other)
+
+    def __truediv__(self, other):
+        return self._get_current_object().__truediv__(other)
+
+    def __neg__(self):
+        return -(self._get_current_object())
+
+    def __pos__(self):
+        return +(self._get_current_object())
+
+    def __abs__(self):
+        return abs(self._get_current_object())
+
+    def __invert__(self):
+        return ~(self._get_current_object())
+
+    def __complex__(self):
+        return complex(self._get_current_object())
+
+    def __int__(self):
+        return int(self._get_current_object())
+
+    def __float__(self):
+        return float(self._get_current_object())
+
+    def __oct__(self):
+        return oct(self._get_current_object())
+
+    def __hex__(self):
+        return hex(self._get_current_object())
+
+    def __index__(self):
+        return self._get_current_object().__index__()
+
+    def __enter__(self):
+        return self._get_current_object().__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        return self._get_current_object().__exit__(*args, **kwargs)

--- a/scheduler/worker/local.py
+++ b/scheduler/worker/local.py
@@ -1,40 +1,29 @@
-# ruff: noqa: E731
-"""
-werkzeug.local
-~~~~~~~~~~~~~~
+from __future__ import annotations
 
-This module implements context-local objects.
+import copy
+import math
+import operator
+import typing as t
+from contextvars import ContextVar
+from functools import partial
+from functools import update_wrapper
+from operator import attrgetter
 
-:copyright: (c) 2011 by the Werkzeug Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
+if t.TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
-# Since each thread has its own greenlet we can just use those as identifiers
-# for the context.  If greenlets are not available we fall back to the
-# current thread ident.
-try:
-    from greenlet import getcurrent as get_ident
-except ImportError:
-    from threading import get_ident  # type: ignore[assignment]
+T = t.TypeVar("T")
+F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
 
-def release_local(local):
-    """Releases the contents of the local for the current context.
-    This makes it possible to use locals without a manager.
+def release_local(local: Local | LocalStack[t.Any]) -> None:
+    """Release the data for the current context in a :class:`Local` or
+    :class:`LocalStack` without using a :class:`LocalManager`.
 
-    Example::
-
-        >>> loc = Local()
-        >>> loc.foo = 42
-        >>> release_local(loc)
-        >>> hasattr(loc, 'foo')
-        False
-
-    With this function one can release :class:`Local` objects as well
-    as :class:`StackLocal` objects.  However it is not possible to
-    release data held by proxies that way, one always has to retain
-    a reference to the underlying local object in order to be able
-    to release it.
+    This should not be needed for modern use cases, and may be removed
+    in the future.
 
     .. versionadded:: 0.6.1
     """
@@ -42,391 +31,655 @@ def release_local(local):
 
 
 class Local:
-    __slots__ = ("__storage__", "__ident_func__")
+    """Create a namespace of context-local data. This wraps a
+    :class:`ContextVar` containing a :class:`dict` value.
 
-    def __init__(self):
-        object.__setattr__(self, "__storage__", {})
-        object.__setattr__(self, "__ident_func__", get_ident)
+    This may incur a performance penalty compared to using individual
+    context vars, as it has to copy data to avoid mutating the dict
+    between nested contexts.
 
-    def __iter__(self):
-        return iter(self.__storage__.items())
+    :param context_var: The :class:`~contextvars.ContextVar` to use as
+        storage for this local. If not given, one will be created.
+        Context vars not created at the global scope may interfere with
+        garbage collection.
 
-    def __call__(self, proxy):
-        """Create a proxy for a name."""
-        return LocalProxy(self, proxy)
+    .. versionchanged:: 2.0
+        Uses ``ContextVar`` instead of a custom storage implementation.
+    """
 
-    def __release_local__(self):
-        self.__storage__.pop(self.__ident_func__(), None)
+    __slots__ = ("__storage",)
 
-    def __getattr__(self, name):
-        try:
-            return self.__storage__[self.__ident_func__()][name]
-        except KeyError:
+    def __init__(self, context_var: ContextVar[dict[str, t.Any]] | None = None) -> None:
+        if context_var is None:
+            # A ContextVar not created at global scope interferes with
+            # Python's garbage collection. However, a local only makes
+            # sense defined at the global scope as well, in which case
+            # the GC issue doesn't seem relevant.
+            context_var = ContextVar(f"werkzeug.Local<{id(self)}>.storage")
+
+        object.__setattr__(self, "_Local__storage", context_var)
+
+    def __iter__(self) -> t.Iterator[tuple[str, t.Any]]:
+        return iter(self.__storage.get({}).items())
+
+    def __call__(self, name: str, *, unbound_message: str | None = None) -> LocalProxy[t.Any]:
+        """Create a :class:`LocalProxy` that access an attribute on this
+        local namespace.
+
+        :param name: Proxy this attribute.
+        :param unbound_message: The error message that the proxy will
+            show if the attribute isn't set.
+        """
+        return LocalProxy(self, name, unbound_message=unbound_message)
+
+    def __release_local__(self) -> None:
+        self.__storage.set({})
+
+    def __getattr__(self, name: str) -> t.Any:
+        values = self.__storage.get({})
+
+        if name in values:
+            return values[name]
+
+        raise AttributeError(name)
+
+    def __setattr__(self, name: str, value: t.Any) -> None:
+        values = self.__storage.get({}).copy()
+        values[name] = value
+        self.__storage.set(values)
+
+    def __delattr__(self, name: str) -> None:
+        values = self.__storage.get({})
+
+        if name in values:
+            values = values.copy()
+            del values[name]
+            self.__storage.set(values)
+        else:
             raise AttributeError(name)
 
-    def __setattr__(self, name, value):
-        ident = self.__ident_func__()
-        storage = self.__storage__
-        try:
-            storage[ident][name] = value
-        except KeyError:
-            storage[ident] = {name: value}
 
-    def __delattr__(self, name):
-        try:
-            del self.__storage__[self.__ident_func__()][name]
-        except KeyError:
-            raise AttributeError(name)
+class LocalStack(t.Generic[T]):
+    """Create a stack of context-local data. This wraps a
+    :class:`ContextVar` containing a :class:`list` value.
 
+    This may incur a performance penalty compared to using individual
+    context vars, as it has to copy data to avoid mutating the list
+    between nested contexts.
 
-class LocalStack:
-    """This class works similar to a :class:`Local` but keeps a stack
-    of objects instead.  This is best explained with an example::
+    :param context_var: The :class:`~contextvars.ContextVar` to use as
+        storage for this local. If not given, one will be created.
+        Context vars not created at the global scope may interfere with
+        garbage collection.
 
-        >>> ls = LocalStack()
-        >>> ls.push(42)
-        >>> ls.top
-        42
-        >>> ls.push(23)
-        >>> ls.top
-        23
-        >>> ls.pop()
-        23
-        >>> ls.top
-        42
-
-    They can be force released by using a :class:`LocalManager` or with
-    the :func:`release_local` function but the correct way is to pop the
-    item from the stack after using.  When the stack is empty it will
-    no longer be bound to the current context (and as such released).
-
-    By calling the stack without arguments it returns a proxy that resolves to
-    the topmost item on the stack.
+    .. versionchanged:: 2.0
+        Uses ``ContextVar`` instead of a custom storage implementation.
 
     .. versionadded:: 0.6.1
     """
 
-    def __init__(self):
-        self._local = Local()
+    __slots__ = ("_storage",)
 
-    def __release_local__(self):
-        self._local.__release_local__()
+    def __init__(self, context_var: ContextVar[list[T]] | None = None) -> None:
+        if context_var is None:
+            # A ContextVar not created at global scope interferes with
+            # Python's garbage collection. However, a local only makes
+            # sense defined at the global scope as well, in which case
+            # the GC issue doesn't seem relevant.
+            context_var = ContextVar(f"werkzeug.LocalStack<{id(self)}>.storage")
 
-    def _get__ident_func__(self):
-        return self._local.__ident_func__
+        self._storage = context_var
 
-    def _set__ident_func__(self, value):
-        object.__setattr__(self._local, "__ident_func__", value)
+    def __release_local__(self) -> None:
+        self._storage.set([])
 
-    __ident_func__ = property(_get__ident_func__, _set__ident_func__)
-    del _get__ident_func__, _set__ident_func__
+    def push(self, obj: T) -> list[T]:
+        """Add a new item to the top of the stack."""
+        stack = self._storage.get([]).copy()
+        stack.append(obj)
+        self._storage.set(stack)
+        return stack
 
-    def __call__(self):
-        def _lookup():
-            rv = self.top
-            if rv is None:
-                raise RuntimeError("object unbound")
-            return rv
+    def pop(self) -> T | None:
+        """Remove the top item from the stack and return it. If the
+        stack is empty, return ``None``.
+        """
+        stack = self._storage.get([])
 
-        return LocalProxy(_lookup)
+        if len(stack) == 0:
+            return None
 
-    def push(self, obj):
-        """Pushes a new item to the stack"""
-        rv = getattr(self._local, "stack", None)
-        if rv is None:
-            self._local.stack = rv = []
-        rv.append(obj)
+        rv = stack[-1]
+        self._storage.set(stack[:-1])
         return rv
 
-    def pop(self):
-        """Removes the topmost item from the stack, will return the
-        old value or `None` if the stack was already empty.
-        """
-        stack = getattr(self._local, "stack", None)
-        if stack is None:
-            return None
-        elif len(stack) == 1:
-            release_local(self._local)
-            return stack[-1]
-        else:
-            return stack.pop()
-
     @property
-    def top(self):
+    def top(self) -> T | None:
         """The topmost item on the stack.  If the stack is empty,
         `None` is returned.
         """
-        try:
-            return self._local.stack[-1]
-        except (AttributeError, IndexError):
+        stack = self._storage.get([])
+
+        if len(stack) == 0:
             return None
 
-    def __len__(self):
-        stack = getattr(self._local, "stack", None)
-        if stack is None:
-            return 0
-        return len(stack)
+        return stack[-1]
+
+    def __call__(self, name: str | None = None, *, unbound_message: str | None = None) -> LocalProxy[t.Any]:
+        """Create a :class:`LocalProxy` that accesses the top of this
+        local stack.
+
+        :param name: If given, the proxy access this attribute of the
+            top item, rather than the item itself.
+        :param unbound_message: The error message that the proxy will
+            show if the stack is empty.
+        """
+        return LocalProxy(self, name, unbound_message=unbound_message)
+
+
+class ClosingIterator:
+    """The WSGI specification requires that all middlewares and gateways
+    respect the `close` callback of the iterable returned by the application.
+    Because it is useful to add another close action to a returned iterable
+    and adding a custom iterable is a boring task this class can be used for
+    that::
+
+        return ClosingIterator(app(environ, start_response), [cleanup_session,
+                                                              cleanup_locals])
+
+    If there is just one close function it can be passed instead of the list.
+
+    A closing iterator is not needed if the application uses response objects
+    and finishes the processing if the response is started::
+
+        try:
+            return response(environ, start_response)
+        finally:
+            cleanup_session()
+            cleanup_locals()
+    """
+
+    def __init__(
+        self,
+        iterable: t.Iterable[bytes],
+        callbacks: None | (t.Callable[[], None] | t.Iterable[t.Callable[[], None]]) = None,
+    ) -> None:
+        iterator = iter(iterable)
+        self._next = t.cast("t.Callable[[], bytes]", partial(next, iterator))
+        if callbacks is None:
+            callbacks = []
+        elif callable(callbacks):
+            callbacks = [callbacks]
+        else:
+            callbacks = list(callbacks)
+        iterable_close = getattr(iterable, "close", None)
+        if iterable_close:
+            callbacks.insert(0, iterable_close)
+        self._callbacks = callbacks
+
+    def __iter__(self) -> ClosingIterator:
+        return self
+
+    def __next__(self) -> bytes:
+        return self._next()
+
+    def close(self) -> None:
+        for callback in self._callbacks:
+            callback()
 
 
 class LocalManager:
-    """Local objects cannot manage themselves. For that you need a local
-    manager.  You can pass a local manager multiple locals or add them later
-    by appending them to `manager.locals`.  Every time the manager cleans up
-    it, will clean up all the data left in the locals for this context.
+    """Manage releasing the data for the current context in one or more
+    :class:`Local` and :class:`LocalStack` objects.
 
-    The `ident_func` parameter can be added to override the default ident
-    function for the wrapped locals.
+    This should not be needed for modern use cases, and may be removed
+    in the future.
 
-    .. versionchanged:: 0.6.1
-       Instead of a manager the :func:`release_local` function can be used
-       as well.
+    :param locals: A local or list of locals to manage.
+
+    .. versionchanged:: 2.1
+        The ``ident_func`` was removed.
 
     .. versionchanged:: 0.7
-       `ident_func` was added.
+        The ``ident_func`` parameter was added.
+
+    .. versionchanged:: 0.6.1
+        The :func:`release_local` function can be used instead of a
+        manager.
     """
 
-    def __init__(self, locals_=None, ident_func=None):
-        if locals_ is None:
+    __slots__ = ("locals",)
+
+    def __init__(
+        self,
+        locals: None | (Local | LocalStack[t.Any] | t.Iterable[Local | LocalStack[t.Any]]) = None,  # noqa: A002
+    ) -> None:
+        if locals is None:
             self.locals = []
-        elif isinstance(locals_, Local):
+        elif isinstance(locals, Local):
             self.locals = [locals]
         else:
-            self.locals = list(locals_)
-        if ident_func is not None:
-            self.ident_func = ident_func
-            for local in self.locals:
-                object.__setattr__(local, "__ident_func__", ident_func)
-        else:
-            self.ident_func = get_ident
+            self.locals = list(locals)  # type: ignore[arg-type]
 
-    def get_ident(self):
-        """Return the context identifier the local objects use internally for
-        this context.  You cannot override this method to change the behavior
-        but use it to link other context local objects (such as SQLAlchemy's
-        scoped sessions) to the Werkzeug locals.
-
-        .. versionchanged:: 0.7
-           You can pass a different ident function to the local manager that
-           will then be propagated to all the locals passed to the
-           constructor.
-        """
-        return self.ident_func()
-
-    def cleanup(self):
-        """Manually clean up the data in the locals for this context.  Call
-        this at the end of the request or use `make_middleware()`.
+    def cleanup(self) -> None:
+        """Release the data in the locals for this context. Call this at
+        the end of each request or use :meth:`make_middleware`.
         """
         for local in self.locals:
             release_local(local)
 
-    def __repr__(self):
-        return f"<{self.__class__.__name__} storages: {len(self.locals)}>"
+    def make_middleware(self, app: WSGIApplication) -> WSGIApplication:
+        """Wrap a WSGI application so that local data is released
+        automatically after the response has been sent for a request.
+        """
+
+        def application(environ: WSGIEnvironment, start_response: StartResponse) -> t.Iterable[bytes]:
+            return ClosingIterator(app(environ, start_response), self.cleanup)
+
+        return application
+
+    def middleware(self, func: WSGIApplication) -> WSGIApplication:
+        """Like :meth:`make_middleware` but used as a decorator on the
+        WSGI application function.
+
+        .. code-block:: python
+
+            @manager.middleware
+            def application(environ, start_response):
+                ...
+        """
+        return update_wrapper(self.make_middleware(func), func)
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} storages: {len(self.locals)}>"
 
 
-class LocalProxy:
-    """Acts as a proxy for a werkzeug local.  Forwards all operations to
-    a proxied object.  The only operations not supported for forwarding
-    are right handed operands and any kind of assignment.
+class _ProxyLookup:
+    """Descriptor that handles proxied attribute lookup for
+    :class:`LocalProxy`.
 
-    Example usage::
-
-        from werkzeug.local import Local
-        l = Local()
-
-        # these are proxies
-        request = l('request')
-        user = l('user')
-
-
-        from werkzeug.local import LocalStack
-        _response_local = LocalStack()
-
-        # this is a proxy
-        response = _response_local()
-
-    Whenever something is bound to l.user / l.request the proxy objects
-    will forward all operations.  If no object is bound a :exc:`RuntimeError`
-    will be raised.
-
-    To create proxies to :class:`Local` or :class:`LocalStack` objects,
-    call the object as shown above.  If you want to have a proxy to an
-    object looked up by a function, you can (as of Werkzeug 0.6.1) pass
-    a function to the :class:`LocalProxy` constructor::
-
-        session = LocalProxy(lambda: get_current_request().session)
-
-    .. versionchanged:: 0.6.1
-       The class can be instantiated with a callable as well now.
+    :param f: The built-in function this attribute is accessed through.
+        Instead of looking up the special method, the function call
+        is redone on the object.
+    :param fallback: Return this function if the proxy is unbound
+        instead of raising a :exc:`RuntimeError`.
+    :param is_attr: This proxied name is an attribute, not a function.
+        Call the fallback immediately to get the value.
+    :param class_value: Value to return when accessed from the
+        ``LocalProxy`` class directly. Used for ``__doc__`` so building
+        docs still works.
     """
 
-    __slots__ = ("__local", "__dict__", "__name__")
+    __slots__ = ("bind_f", "fallback", "is_attr", "class_value", "name")
 
-    def __init__(self, local, name=None):
-        object.__setattr__(self, "_LocalProxy__local", local)
-        object.__setattr__(self, "__name__", name)
+    def __init__(
+        self,
+        f: t.Callable[..., t.Any] | None = None,
+        fallback: t.Callable[[LocalProxy[t.Any]], t.Any] | None = None,
+        class_value: t.Any | None = None,
+        is_attr: bool = False,
+    ) -> None:
+        bind_f: t.Callable[[LocalProxy[t.Any], t.Any], t.Callable[..., t.Any]] | None
 
-    def _get_current_object(self):
-        """Return the current object.  This is useful if you want the real
-        object behind the proxy at a time for performance reasons or because
-        you want to pass the object into a different context.
+        if hasattr(f, "__get__"):
+            # A Python function, can be turned into a bound method.
+
+            def bind_f(instance: LocalProxy[t.Any], obj: t.Any) -> t.Callable[..., t.Any]:
+                return f.__get__(obj, type(obj))  # type: ignore
+
+        elif f is not None:
+            # A C function, use partial to bind the first argument.
+
+            def bind_f(instance: LocalProxy[t.Any], obj: t.Any) -> t.Callable[..., t.Any]:
+                return partial(f, obj)
+
+        else:
+            # Use getattr, which will produce a bound method.
+            bind_f = None
+
+        self.bind_f = bind_f
+        self.fallback = fallback
+        self.class_value = class_value
+        self.is_attr = is_attr
+
+    def __set_name__(self, owner: LocalProxy[t.Any], name: str) -> None:
+        self.name = name
+
+    def __get__(self, instance: LocalProxy[t.Any], owner: type | None = None) -> t.Any:
+        if instance is None:
+            if self.class_value is not None:
+                return self.class_value
+
+            return self
+
+        try:
+            obj = instance._get_current_object()
+        except RuntimeError:
+            if self.fallback is None:
+                raise
+
+            fallback = self.fallback.__get__(instance, owner)
+
+            if self.is_attr:
+                # __class__ and __doc__ are attributes, not methods.
+                # Call the fallback to get the value.
+                return fallback()
+
+            return fallback
+
+        if self.bind_f is not None:
+            return self.bind_f(instance, obj)
+
+        return getattr(obj, self.name)
+
+    def __repr__(self) -> str:
+        return f"proxy {self.name}"
+
+    def __call__(self, instance: LocalProxy[t.Any], *args: t.Any, **kwargs: t.Any) -> t.Any:
+        """Support calling unbound methods from the class. For example,
+        this happens with ``copy.copy``, which does
+        ``type(x).__copy__(x)``. ``type(x)`` can't be proxied, so it
+        returns the proxy type and descriptor.
         """
-        if not hasattr(self.__local, "__release_local__"):
-            return self.__local()
-        try:
-            return getattr(self.__local, self.__name__)
-        except AttributeError:
-            raise RuntimeError(f"no object bound to {self.__name__}")
+        return self.__get__(instance, type(instance))(*args, **kwargs)
 
-    @property
-    def __dict__(self):
-        try:
-            return self._get_current_object().__dict__
-        except RuntimeError:
-            raise AttributeError("__dict__")
 
-    def __repr__(self):
-        try:
-            obj = self._get_current_object()
-        except RuntimeError:
-            return f"<{self.__class__.__name__} unbound>"
-        return repr(obj)
+class _ProxyIOp(_ProxyLookup):
+    """Look up an augmented assignment method on a proxied object. The
+    method is wrapped to return the proxy instead of the object.
+    """
 
-    def __dir__(self):
-        try:
-            return dir(self._get_current_object())
-        except RuntimeError:
-            return []
+    __slots__ = ()
 
-    def __getattr__(self, name):
-        if name == "__members__":
-            return dir(self._get_current_object())
-        return getattr(self._get_current_object(), name)
+    def __init__(
+        self,
+        f: t.Callable[..., t.Any] | None = None,
+        fallback: t.Callable[[LocalProxy[t.Any]], t.Any] | None = None,
+    ) -> None:
+        super().__init__(f, fallback)
 
-    def __setitem__(self, key, value):
-        self._get_current_object()[key] = value
+        def bind_f(instance: LocalProxy[t.Any], obj: t.Any) -> t.Callable[..., t.Any]:
+            def i_op(self: t.Any, other: t.Any) -> LocalProxy[t.Any]:
+                f(self, other)  # type: ignore
+                return instance
 
-    def __delitem__(self, key):
-        del self._get_current_object()[key]
+            return i_op.__get__(obj, type(obj))  # type: ignore
 
-    def __setattr__(self, name, value):
-        setattr(self._get_current_object(), name, value)
+        self.bind_f = bind_f
 
-    def __delattr__(self, name):
-        return delattr(self._get_current_object(), name)
 
-    def __str__(self):
-        return str(self._get_current_object())
+def _l_to_r_op(op: F) -> F:
+    """Swap the argument order to turn an l-op into an r-op."""
 
-    def __lt__(self, other):
-        return self._get_current_object() < other
+    def r_op(obj: t.Any, other: t.Any) -> t.Any:
+        return op(other, obj)
 
-    def __le__(self, other):
-        return self._get_current_object() <= other
+    return t.cast("F", r_op)
 
-    def __eq__(self, other):
-        return self._get_current_object() == other
 
-    def __ne__(self, other):
-        return self._get_current_object() != other
+def _identity(o: T) -> T:
+    return o
 
-    def __gt__(self, other):
-        return self._get_current_object() > other
 
-    def __ge__(self, other):
-        return self._get_current_object() >= other
+class LocalProxy(t.Generic[T]):
+    """A proxy to the object bound to a context-local object. All
+    operations on the proxy are forwarded to the bound object. If no
+    object is bound, a ``RuntimeError`` is raised.
 
-    def __hash__(self):
-        return hash(self._get_current_object())
+    :param local: The context-local object that provides the proxied
+        object.
+    :param name: Proxy this attribute from the proxied object.
+    :param unbound_message: The error message to show if the
+        context-local object is unbound.
 
-    def __call__(self, *args, **kwargs):
-        return self._get_current_object()(*args, **kwargs)
+    Proxy a :class:`~contextvars.ContextVar` to make it easier to
+    access. Pass a name to proxy that attribute.
 
-    def __len__(self):
-        return len(self._get_current_object())
+    .. code-block:: python
 
-    def __getitem__(self, i):
-        return self._get_current_object()[i]
+        _request_var = ContextVar("request")
+        request = LocalProxy(_request_var)
+        session = LocalProxy(_request_var, "session")
 
-    def __iter__(self):
-        return iter(self._get_current_object())
+    Proxy an attribute on a :class:`Local` namespace by calling the
+    local with the attribute name:
 
-    def __contains__(self, obj):
-        return obj in self._get_current_object()
+    .. code-block:: python
 
-    def __add__(self, other):
-        return self._get_current_object() + other
+        data = Local()
+        user = data("user")
 
-    def __sub__(self, other):
-        return self._get_current_object() - other
+    Proxy the top item on a :class:`LocalStack` by calling the local.
+    Pass a name to proxy that attribute.
 
-    def __mul__(self, other):
-        return self._get_current_object() * other
+    .. code-block::
 
-    def __floordiv__(self, other):
-        return self._get_current_object() // other
+        app_stack = LocalStack()
+        current_app = app_stack()
+        g = app_stack("g")
 
-    def __mod__(self, other):
-        return self._get_current_object() % other
+    Pass a function to proxy the return value from that function. This
+    was previously used to access attributes of local objects before
+    that was supported directly.
 
-    def __divmod__(self, other):
-        return self._get_current_object().__divmod__(other)
+    .. code-block:: python
 
-    def __pow__(self, other):
-        return self._get_current_object() ** other
+        session = LocalProxy(lambda: request.session)
 
-    def __lshift__(self, other):
-        return self._get_current_object() << other
+    ``__repr__`` and ``__class__`` are proxied, so ``repr(x)`` and
+    ``isinstance(x, cls)`` will look like the proxied object. Use
+    ``issubclass(type(x), LocalProxy)`` to check if an object is a
+    proxy.
 
-    def __rshift__(self, other):
-        return self._get_current_object() >> other
+    .. code-block:: python
 
-    def __and__(self, other):
-        return self._get_current_object() & other
+        repr(user)  # <User admin>
+        isinstance(user, User)  # True
+        issubclass(type(user), LocalProxy)  # True
 
-    def __xor__(self, other):
-        return self._get_current_object() ^ other
+    .. versionchanged:: 2.2.2
+        ``__wrapped__`` is set when wrapping an object, not only when
+        wrapping a function, to prevent doctest from failing.
 
-    def __or__(self, other):
-        return self._get_current_object() | other
+    .. versionchanged:: 2.2
+        Can proxy a ``ContextVar`` or ``LocalStack`` directly.
 
-    def __div__(self, other):
-        return self._get_current_object().__div__(other)
+    .. versionchanged:: 2.2
+        The ``name`` parameter can be used with any proxied object, not
+        only ``Local``.
 
-    def __truediv__(self, other):
-        return self._get_current_object().__truediv__(other)
+    .. versionchanged:: 2.2
+        Added the ``unbound_message`` parameter.
 
-    def __neg__(self):
-        return -(self._get_current_object())
+    .. versionchanged:: 2.0
+        Updated proxied attributes and methods to reflect the current
+        data model.
 
-    def __pos__(self):
-        return +(self._get_current_object())
+    .. versionchanged:: 0.6.1
+        The class can be instantiated with a callable.
+    """
 
-    def __abs__(self):
-        return abs(self._get_current_object())
+    __slots__ = ("__wrapped", "_get_current_object")
 
-    def __invert__(self):
-        return ~(self._get_current_object())
+    _get_current_object: t.Callable[[], T]
+    """Return the current object this proxy is bound to. If the proxy is
+    unbound, this raises a ``RuntimeError``.
 
-    def __complex__(self):
-        return complex(self._get_current_object())
+    This should be used if you need to pass the object to something that
+    doesn't understand the proxy. It can also be useful for performance
+    if you are accessing the object multiple times in a function, rather
+    than going through the proxy multiple times.
+    """
 
-    def __int__(self):
-        return int(self._get_current_object())
+    def __init__(  # noqa: C901
+        self,
+        local: ContextVar[T] | Local | LocalStack[T] | t.Callable[[], T],
+        name: str | None = None,
+        *,
+        unbound_message: str | None = None,
+    ) -> None:
+        if name is None:
+            get_name = _identity
+        else:
+            get_name = attrgetter(name)  # type: ignore[assignment]
 
-    def __float__(self):
-        return float(self._get_current_object())
+        if unbound_message is None:
+            unbound_message = "object is not bound"
 
-    def __oct__(self):
-        return oct(self._get_current_object())
+        if isinstance(local, Local):
+            if name is None:
+                raise TypeError("'name' is required when proxying a 'Local' object.")
 
-    def __hex__(self):
-        return hex(self._get_current_object())
+            def _get_current_object() -> T:
+                try:
+                    return get_name(local)  # type: ignore[return-value]
+                except AttributeError:
+                    raise RuntimeError(unbound_message) from None
 
-    def __index__(self):
-        return self._get_current_object().__index__()
+        elif isinstance(local, LocalStack):
 
-    def __enter__(self):
-        return self._get_current_object().__enter__()
+            def _get_current_object() -> T:
+                obj = local.top
 
-    def __exit__(self, *args, **kwargs):
-        return self._get_current_object().__exit__(*args, **kwargs)
+                if obj is None:
+                    raise RuntimeError(unbound_message)
+
+                return get_name(obj)
+
+        elif isinstance(local, ContextVar):
+
+            def _get_current_object() -> T:
+                try:
+                    obj = local.get()
+                except LookupError:
+                    raise RuntimeError(unbound_message) from None
+
+                return get_name(obj)
+
+        elif callable(local):
+
+            def _get_current_object() -> T:
+                return get_name(local())
+
+        else:
+            raise TypeError(f"Don't know how to proxy '{type(local)}'.")
+
+        object.__setattr__(self, "_LocalProxy__wrapped", local)
+        object.__setattr__(self, "_get_current_object", _get_current_object)
+
+    __doc__ = _ProxyLookup(class_value=__doc__, fallback=lambda self: type(self).__doc__, is_attr=True)
+    __wrapped__ = _ProxyLookup(
+        fallback=lambda self: self._LocalProxy__wrapped,  # type: ignore[attr-defined]
+        is_attr=True,
+    )
+    # __del__ should only delete the proxy
+    __repr__ = _ProxyLookup(repr, fallback=lambda self: f"<{type(self).__name__} unbound>")
+    __str__ = _ProxyLookup(str)
+    __bytes__ = _ProxyLookup(bytes)
+    __format__ = _ProxyLookup()
+    __lt__ = _ProxyLookup(operator.lt)
+    __le__ = _ProxyLookup(operator.le)
+    __eq__ = _ProxyLookup(operator.eq)
+    __ne__ = _ProxyLookup(operator.ne)
+    __gt__ = _ProxyLookup(operator.gt)
+    __ge__ = _ProxyLookup(operator.ge)
+    __hash__ = _ProxyLookup(hash)
+    __bool__ = _ProxyLookup(bool, fallback=lambda self: False)
+    __getattr__ = _ProxyLookup(getattr)
+    # __getattribute__ triggered through __getattr__
+    __setattr__ = _ProxyLookup(setattr)
+    __delattr__ = _ProxyLookup(delattr)
+    __dir__ = _ProxyLookup(dir, fallback=lambda self: [])
+    # __get__ (proxying descriptor not supported)
+    # __set__ (descriptor)
+    # __delete__ (descriptor)
+    # __set_name__ (descriptor)
+    # __objclass__ (descriptor)
+    # __slots__ used by proxy itself
+    # __dict__ (__getattr__)
+    # __weakref__ (__getattr__)
+    # __init_subclass__ (proxying metaclass not supported)
+    # __prepare__ (metaclass)
+    __class__ = _ProxyLookup(fallback=lambda self: type(self), is_attr=True)
+    __instancecheck__ = _ProxyLookup(lambda self, other: isinstance(other, self))
+    __subclasscheck__ = _ProxyLookup(lambda self, other: issubclass(other, self))
+    # __class_getitem__ triggered through __getitem__
+    __call__ = _ProxyLookup(lambda self, *args, **kwargs: self(*args, **kwargs))
+    __len__ = _ProxyLookup(len)
+    __length_hint__ = _ProxyLookup(operator.length_hint)
+    __getitem__ = _ProxyLookup(operator.getitem)
+    __setitem__ = _ProxyLookup(operator.setitem)
+    __delitem__ = _ProxyLookup(operator.delitem)
+    # __missing__ triggered through __getitem__
+    __iter__ = _ProxyLookup(iter)
+    __next__ = _ProxyLookup(next)
+    __reversed__ = _ProxyLookup(reversed)
+    __contains__ = _ProxyLookup(operator.contains)
+    __add__ = _ProxyLookup(operator.add)
+    __sub__ = _ProxyLookup(operator.sub)
+    __mul__ = _ProxyLookup(operator.mul)
+    __matmul__ = _ProxyLookup(operator.matmul)
+    __truediv__ = _ProxyLookup(operator.truediv)
+    __floordiv__ = _ProxyLookup(operator.floordiv)
+    __mod__ = _ProxyLookup(operator.mod)
+    __divmod__ = _ProxyLookup(divmod)
+    __pow__ = _ProxyLookup(pow)
+    __lshift__ = _ProxyLookup(operator.lshift)
+    __rshift__ = _ProxyLookup(operator.rshift)
+    __and__ = _ProxyLookup(operator.and_)
+    __xor__ = _ProxyLookup(operator.xor)
+    __or__ = _ProxyLookup(operator.or_)
+    __radd__ = _ProxyLookup(_l_to_r_op(operator.add))
+    __rsub__ = _ProxyLookup(_l_to_r_op(operator.sub))
+    __rmul__ = _ProxyLookup(_l_to_r_op(operator.mul))
+    __rmatmul__ = _ProxyLookup(_l_to_r_op(operator.matmul))
+    __rtruediv__ = _ProxyLookup(_l_to_r_op(operator.truediv))
+    __rfloordiv__ = _ProxyLookup(_l_to_r_op(operator.floordiv))
+    __rmod__ = _ProxyLookup(_l_to_r_op(operator.mod))
+    __rdivmod__ = _ProxyLookup(_l_to_r_op(divmod))
+    __rpow__ = _ProxyLookup(_l_to_r_op(pow))
+    __rlshift__ = _ProxyLookup(_l_to_r_op(operator.lshift))
+    __rrshift__ = _ProxyLookup(_l_to_r_op(operator.rshift))
+    __rand__ = _ProxyLookup(_l_to_r_op(operator.and_))
+    __rxor__ = _ProxyLookup(_l_to_r_op(operator.xor))
+    __ror__ = _ProxyLookup(_l_to_r_op(operator.or_))
+    __iadd__ = _ProxyIOp(operator.iadd)
+    __isub__ = _ProxyIOp(operator.isub)
+    __imul__ = _ProxyIOp(operator.imul)
+    __imatmul__ = _ProxyIOp(operator.imatmul)
+    __itruediv__ = _ProxyIOp(operator.itruediv)
+    __ifloordiv__ = _ProxyIOp(operator.ifloordiv)
+    __imod__ = _ProxyIOp(operator.imod)
+    __ipow__ = _ProxyIOp(operator.ipow)
+    __ilshift__ = _ProxyIOp(operator.ilshift)
+    __irshift__ = _ProxyIOp(operator.irshift)
+    __iand__ = _ProxyIOp(operator.iand)
+    __ixor__ = _ProxyIOp(operator.ixor)
+    __ior__ = _ProxyIOp(operator.ior)
+    __neg__ = _ProxyLookup(operator.neg)
+    __pos__ = _ProxyLookup(operator.pos)
+    __abs__ = _ProxyLookup(abs)
+    __invert__ = _ProxyLookup(operator.invert)
+    __complex__ = _ProxyLookup(complex)
+    __int__ = _ProxyLookup(int)
+    __float__ = _ProxyLookup(float)
+    __index__ = _ProxyLookup(operator.index)
+    __round__ = _ProxyLookup(round)
+    __trunc__ = _ProxyLookup(math.trunc)
+    __floor__ = _ProxyLookup(math.floor)
+    __ceil__ = _ProxyLookup(math.ceil)
+    __enter__ = _ProxyLookup()
+    __exit__ = _ProxyLookup()
+    __await__ = _ProxyLookup()
+    __aiter__ = _ProxyLookup()
+    __anext__ = _ProxyLookup()
+    __aenter__ = _ProxyLookup()
+    __aexit__ = _ProxyLookup()
+    __copy__ = _ProxyLookup(copy.copy)
+    __deepcopy__ = _ProxyLookup(copy.deepcopy)
+    # __getnewargs_ex__ (pickle through proxy not supported)
+    # __getnewargs__ (pickle)
+    # __getstate__ (pickle)
+    # __setstate__ (pickle)
+    # __reduce__ (pickle)
+    # __reduce_ex__ (pickle)

--- a/scheduler/worker/worker.py
+++ b/scheduler/worker/worker.py
@@ -25,6 +25,7 @@ from scheduler.types import Broker, Self
 from scheduler.types import ConnectionType, TimeoutErrorTypes, ConnectionErrorTypes, WatchErrorTypes, ResponseErrorTypes
 from .commands import WorkerCommandsChannelListener
 from .scheduler import WorkerScheduler, SchedulerStatus
+from .local import LocalStack
 from ..helpers.queues.getters import get_queue_connection
 from ..redis_models.lock import QueueLock
 from ..redis_models.worker import WorkerStatus
@@ -62,6 +63,8 @@ _signames = {
     getattr(signal, signame): signame for signame in dir(signal) if signame.startswith("SIG") and "_" not in signame
 }
 
+_job_stack = LocalStack()
+
 
 def signal_name(signum: int) -> str:
     try:
@@ -70,6 +73,17 @@ def signal_name(signum: int) -> str:
         return "SIG_UNKNOWN"
     except ValueError:
         return "SIG_UNKNOWN"
+
+
+def get_current_job() -> Optional[JobModel]:
+    """Returns the Job instance that is currently being executed.
+    If this function is invoked from outside a job context, None is returned.
+
+    Returns:
+        job (Optional[JobModel]): The current Job running
+    """
+
+    return _job_stack.top
 
 
 class DequeueStrategy(str, Enum):
@@ -743,6 +757,7 @@ class Worker:
         """
         self.log(DEBUG, f"Performing {job.name} code.")
 
+        _job_stack.push(job)
         try:
             connection = self.connection
             self.worker_before_execution(job, connection=connection)
@@ -762,6 +777,8 @@ class Worker:
             self.handle_job_failure(job=job, exc_string=exc_string, queue=queue)
             self.handle_exception(job, *exc_info)
             return False
+        finally:
+            assert job is _job_stack.pop()
 
         self.log(INFO, f"queue:{queue.name}/job:{job.name} performed.")
         self.log(DEBUG, f"job:{job.name} result: {str(rv)}")


### PR DESCRIPTION
This is a naive copy of rq's get_current_job() mechanism, based on the same underlying localstack implementation.

Note: [scheduler/worker/local.py](https://github.com/django-commons/django-tasks-scheduler/pull/373/changes/ad6052836cd85e0226d605980f416e5c3dd7ab19#diff-49dd0c9615d21e7822b9b8cf03250fb8db1fdf0e47d2cbc41392cedb322f1c08) was lifted directly from RQ (and slightly adapted to pass linting tests), which got it from [Werkzeug](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/local.py). The file is licensed under BSD, please confirm it's compatible with this package's MIT licence.

Fixes #326 