### PR TITLE
Fix unreachable-queue hangs in views and drop permanent bad-config cache

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,8 @@ SCHEDULER_CONFIG = SchedulerConfiguration(
     DEFAULT_MAINTENANCE_TASK_INTERVAL=10 * 60,  # The interval to run maintenance tasks in seconds. 10 minutes.
     DEFAULT_JOB_MONITORING_INTERVAL=30,  # The interval to monitor jobs in seconds.
     SCHEDULER_FALLBACK_PERIOD_SECS=120,  # Period (secs) to wait before requiring to reacquire locks
+    FAIL_FAST_QUEUE_PROBING=True,  # Use fail-fast connections when admin views probe every queue
+    QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT=2.0,  # Socket connect timeout (seconds) for those probes
 )
 SCHEDULER_QUEUES: Dict[str, QueueConfiguration] = {
     'default': QueueConfiguration(
@@ -99,6 +101,23 @@ The interval to monitor jobs in seconds.
 ### SCHEDULER_CONFIG: `SCHEDULER_FALLBACK_PERIOD_SECS`
 
 Period (secs) to wait before requiring to reacquire locks.
+
+### SCHEDULER_CONFIG: `FAIL_FAST_QUEUE_PROBING`
+
+Admin views that probe every configured queue for read-only operations (e.g. locating a job across
+queues, queue/worker statistics) use a short-timeout, no-retry connection by default, so a single
+unreachable queue cannot stall the request for several seconds (redis-py >= 8 retries connection
+errors with backoff by default). Set to `False` to use each queue's configured connection settings
+unmodified for these probes too, e.g. if retries are required even there.
+
+Default: `True`.
+
+### SCHEDULER_CONFIG: `QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT`
+
+Socket connect timeout (seconds) applied to queue connections when `FAIL_FAST_QUEUE_PROBING` is
+enabled.
+
+Default: `2.0`.
 
 ### SCHEDULER_CONFIG: `TOKEN_VALIDATION_METHOD`
 

--- a/scheduler/helpers/queues/getters.py
+++ b/scheduler/helpers/queues/getters.py
@@ -1,36 +1,59 @@
-from typing import Set
+from typing import Any, Dict, Set
 
 from scheduler.redis_models.worker import WorkerModel
 from scheduler.settings import SCHEDULER_CONFIG, get_queue_names, get_queue_configuration, logger
 from scheduler.types import ConnectionErrorTypes, BrokerMetaData, Broker, ConnectionType, QueueConfiguration
 from .queue_logic import Queue
 
-_BAD_QUEUE_CONFIGURATION = set()
+
+def _fail_fast_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Returns a copy of `kwargs` with short-timeout, no-retry connection settings applied, unless the
+    user already configured them explicitly (see `SchedulerConfiguration.FAIL_FAST_QUEUE_PROBING`)."""
+    kwargs = dict(kwargs)
+    kwargs.setdefault("socket_connect_timeout", SCHEDULER_CONFIG.QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT)
+    kwargs.setdefault("retry", None)
+    return kwargs
 
 
-def _get_connection(config: QueueConfiguration, use_strict_broker: bool = False) -> ConnectionType:
-    """Returns a Broker connection to use based on parameters in SCHEDULER_QUEUES"""
+def _get_connection(
+    config: QueueConfiguration, use_strict_broker: bool = False, fail_fast: bool = False
+) -> ConnectionType:
+    """Returns a Broker connection to use based on parameters in SCHEDULER_QUEUES.
+
+    `fail_fast` is used by admin views that probe every configured queue for read-only operations
+    (e.g. locating a job across queues, queue/worker statistics), so that a single unreachable queue
+    cannot stall the request for several seconds (redis-py >= 8 retries connection errors with backoff
+    by default). See `SchedulerConfiguration.FAIL_FAST_QUEUE_PROBING` to opt out.
+    """
     if SCHEDULER_CONFIG.BROKER == Broker.FAKEREDIS:
         import fakeredis
 
         broker_cls = fakeredis.FakeRedis if not use_strict_broker else fakeredis.FakeStrictRedis
     else:
         broker_cls = BrokerMetaData[(SCHEDULER_CONFIG.BROKER, use_strict_broker)].connection_type
+
+    apply_fail_fast = fail_fast and SCHEDULER_CONFIG.FAIL_FAST_QUEUE_PROBING
+    connection_kwargs = config.CONNECTION_KWARGS or {}
+    if apply_fail_fast:
+        connection_kwargs = _fail_fast_kwargs(connection_kwargs)
+
     if config.URL:
-        return broker_cls.from_url(config.URL, db=config.DB, **(config.CONNECTION_KWARGS or {}))
+        return broker_cls.from_url(config.URL, db=config.DB, **connection_kwargs)
     if config.UNIX_SOCKET_PATH:
         return broker_cls(unix_socket_path=config.UNIX_SOCKET_PATH, db=config.DB)
 
     if config.SENTINELS:
-        connection_kwargs = {
+        full_connection_kwargs = {
             "db": config.DB,
             "password": config.PASSWORD,
             "username": config.USERNAME,
         }
-        connection_kwargs.update(config.CONNECTION_KWARGS or {})
+        full_connection_kwargs.update(connection_kwargs)
         sentinel_kwargs = config.SENTINEL_KWARGS or {}
+        if apply_fail_fast:
+            sentinel_kwargs = _fail_fast_kwargs(sentinel_kwargs)
         SentinelClass = BrokerMetaData[(SCHEDULER_CONFIG.BROKER, use_strict_broker)].sentinel_type
-        sentinel = SentinelClass(config.SENTINELS, sentinel_kwargs=sentinel_kwargs, **connection_kwargs)
+        sentinel = SentinelClass(config.SENTINELS, sentinel_kwargs=sentinel_kwargs, **full_connection_kwargs)
         return sentinel.master_for(  # type: ignore
             service_name=config.MASTER_NAME,
             redis_class=broker_cls,
@@ -42,21 +65,21 @@ def _get_connection(config: QueueConfiguration, use_strict_broker: bool = False)
         db=config.DB,
         username=config.USERNAME,
         password=config.PASSWORD,
-        **(config.CONNECTION_KWARGS or {}),
+        **connection_kwargs,
     )
 
 
-def get_queue_connection(queue_name: str) -> ConnectionType:
+def get_queue_connection(queue_name: str, fail_fast: bool = False) -> ConnectionType:
     queue_settings = get_queue_configuration(queue_name)
-    connection = _get_connection(queue_settings)
+    connection = _get_connection(queue_settings, fail_fast=fail_fast)
     return connection
 
 
-def get_queue(name: str = "default") -> Queue:
+def get_queue(name: str = "default", fail_fast: bool = False) -> Queue:
     """Returns an DjangoQueue using parameters defined in `SCHEDULER_QUEUES`"""
     queue_settings = get_queue_configuration(name)
     is_async = queue_settings.ASYNC
-    connection = _get_connection(queue_settings)
+    connection = _get_connection(queue_settings, fail_fast=fail_fast)
     return Queue(name=name, connection=connection, is_async=is_async)
 
 
@@ -65,13 +88,10 @@ def get_all_workers() -> Set[WorkerModel]:
 
     workers_set: Set[WorkerModel] = set()
     for queue_name in queue_names:
-        if queue_name in _BAD_QUEUE_CONFIGURATION:
-            continue
-        connection = _get_connection(get_queue_configuration(queue_name))
+        connection = _get_connection(get_queue_configuration(queue_name), fail_fast=True)
         try:
             curr_workers: Set[WorkerModel] = set(WorkerModel.all(connection=connection))
             workers_set.update(curr_workers)
         except ConnectionErrorTypes as e:
             logger.error(f"Could not connect for queue {queue_name}: {e}")
-            _BAD_QUEUE_CONFIGURATION.add(queue_name)
     return workers_set

--- a/scheduler/tests/test_queue_getters.py
+++ b/scheduler/tests/test_queue_getters.py
@@ -1,0 +1,81 @@
+import time
+
+from redis.retry import Retry
+
+from scheduler.helpers.queues.getters import _fail_fast_kwargs, _get_connection
+from scheduler.settings import SCHEDULER_CONFIG
+from scheduler.tests.testtools import SchedulerBaseCase
+from scheduler.types import Broker, QueueConfiguration
+
+
+class TestFailFastKwargs(SchedulerBaseCase):
+    def test_defaults_are_injected_when_absent(self):
+        kwargs = _fail_fast_kwargs({})
+        self.assertIsNone(kwargs["retry"])
+        self.assertEqual(kwargs["socket_connect_timeout"], SCHEDULER_CONFIG.QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT)
+
+    def test_user_configured_values_are_respected(self):
+        retry = Retry(None, 3)
+        kwargs = _fail_fast_kwargs({"retry": retry, "socket_connect_timeout": 42})
+        self.assertIs(kwargs["retry"], retry)
+        self.assertEqual(kwargs["socket_connect_timeout"], 42)
+
+    def test_does_not_mutate_input(self):
+        original = {}
+        _fail_fast_kwargs(original)
+        self.assertEqual(original, {})
+
+
+class TestGetConnectionFailFast(SchedulerBaseCase):
+    """Covers https://github.com/django-commons/django-tasks-scheduler/issues/378:
+    unreachable queues should fail fast when views probe every configured queue, and that
+    should be controllable via SCHEDULER_CONFIG.FAIL_FAST_QUEUE_PROBING.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._orig_broker = SCHEDULER_CONFIG.BROKER
+        self._orig_fail_fast = SCHEDULER_CONFIG.FAIL_FAST_QUEUE_PROBING
+        # These tests exercise real redis-py connection construction/kwargs, regardless of
+        # whether the suite is otherwise running against fakeredis.
+        SCHEDULER_CONFIG.BROKER = Broker.REDIS
+
+    def tearDown(self) -> None:
+        SCHEDULER_CONFIG.BROKER = self._orig_broker
+        SCHEDULER_CONFIG.FAIL_FAST_QUEUE_PROBING = self._orig_fail_fast
+        super().tearDown()
+
+    def test_fail_fast_true_applies_short_timeout_and_disables_retry(self):
+        config = QueueConfiguration(HOST="localhost", PORT=1, DB=0)
+        connection = _get_connection(config, fail_fast=True)
+        kwargs = connection.connection_pool.connection_kwargs
+        self.assertIsNone(kwargs["retry"])
+        self.assertEqual(kwargs["socket_connect_timeout"], SCHEDULER_CONFIG.QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT)
+
+    def test_fail_fast_false_uses_default_connection_settings(self):
+        config = QueueConfiguration(HOST="localhost", PORT=1, DB=0)
+        connection = _get_connection(config, fail_fast=False)
+        kwargs = connection.connection_pool.connection_kwargs
+        self.assertIsNotNone(kwargs["retry"])
+
+    def test_fail_fast_respects_user_configured_connection_kwargs(self):
+        config = QueueConfiguration(HOST="localhost", PORT=1, DB=0, CONNECTION_KWARGS={"socket_connect_timeout": 7})
+        connection = _get_connection(config, fail_fast=True)
+        kwargs = connection.connection_pool.connection_kwargs
+        self.assertEqual(kwargs["socket_connect_timeout"], 7)
+        self.assertIsNone(kwargs["retry"])
+
+    def test_fail_fast_probing_can_be_disabled_globally(self):
+        SCHEDULER_CONFIG.FAIL_FAST_QUEUE_PROBING = False
+        config = QueueConfiguration(HOST="localhost", PORT=1, DB=0)
+        connection = _get_connection(config, fail_fast=True)
+        kwargs = connection.connection_pool.connection_kwargs
+        self.assertIsNotNone(kwargs["retry"])
+
+    def test_unreachable_queue_with_fail_fast_does_not_retry_with_backoff(self):
+        config = QueueConfiguration(HOST="localhost", PORT=1, DB=0)
+        connection = _get_connection(config, fail_fast=True)
+        start = time.time()
+        with self.assertRaises(Exception):
+            connection.ping()
+        self.assertLess(time.time() - start, 1.0)

--- a/scheduler/types/settings_types.py
+++ b/scheduler/types/settings_types.py
@@ -43,6 +43,14 @@ class SchedulerConfiguration:
     DEFAULT_JOB_MONITORING_INTERVAL: int = 30  # The interval to monitor jobs in seconds.
     SCHEDULER_FALLBACK_PERIOD_SECS: int = 120  # Period (secs) to wait before requiring to reacquire locks
     DEATH_PENALTY_CLASS: Type[BaseDeathPenalty] = _DEATH_PENALTY_CLASS
+    # Admin views that probe every configured queue for read-only operations (e.g. locating a job across
+    # queues, queue/worker statistics) use a short-timeout, no-retry connection by default, so a single
+    # unreachable queue cannot stall the request for several seconds (redis-py >= 8 retries connection
+    # errors with backoff by default). Set to False to use each queue's configured connection settings
+    # unmodified for these probes too, e.g. if retries are required even there.
+    FAIL_FAST_QUEUE_PROBING: bool = True
+    # Socket connect timeout (seconds) applied to queue connections when FAIL_FAST_QUEUE_PROBING is enabled.
+    QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT: float = 2.0
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)

--- a/scheduler/views/helpers.py
+++ b/scheduler/views/helpers.py
@@ -14,12 +14,10 @@ from scheduler.redis_models import JobModel
 from scheduler.settings import QueueNotFoundError
 from scheduler.settings import get_queue_names, logger
 
-_QUEUES_WITH_BAD_CONFIGURATION = set()
 
-
-def get_queue(queue_name: str) -> Queue:
+def get_queue(queue_name: str, fail_fast: bool = False) -> Queue:
     try:
-        return get_queue_base(queue_name)
+        return get_queue_base(queue_name, fail_fast=fail_fast)
     except QueueNotFoundError as e:
         logger.error(e)
         raise Http404(e)
@@ -28,17 +26,13 @@ def get_queue(queue_name: str) -> Queue:
 def _find_job(job_name: str) -> Tuple[Optional[Queue], Optional[JobModel]]:
     queue_names = get_queue_names()
     for queue_name in queue_names:
-        if queue_name in _QUEUES_WITH_BAD_CONFIGURATION:
-            continue
         try:
-            queue = get_queue(queue_name)
+            queue = get_queue(queue_name, fail_fast=True)
             job = JobModel.get(job_name, connection=queue.connection)
             if job is not None and job.queue_name == queue_name:
                 return queue, job
         except Exception as e:
-            _QUEUES_WITH_BAD_CONFIGURATION.add(queue_name)
-            logger.debug(f"Queue {queue_name} added to bad configuration - Got exception: {e}")
-            pass
+            logger.debug(f"Could not check queue {queue_name} for job {job_name} - Got exception: {e}")
     return None, None
 
 

--- a/scheduler/views/queue_views.py
+++ b/scheduler/views/queue_views.py
@@ -124,7 +124,7 @@ def get_statistics(run_maintenance_tasks: bool = False) -> Dict[str, List[Dict[s
             queue_workers_count[queue_name] += 1
     for queue_name in queue_names:
         try:
-            queue = get_queue(queue_name)
+            queue = get_queue(queue_name, fail_fast=True)
             connection_kwargs = queue.connection.connection_pool.connection_kwargs
 
             if run_maintenance_tasks:


### PR DESCRIPTION
## Summary
- Views that probe every configured queue (`_find_job`, `get_all_workers`, `get_statistics`) now request fail-fast connections: a short `socket_connect_timeout` and disabled connection retries, applied only where the user hasn't already configured those settings explicitly. redis-py >= 8 retries connection errors with backoff by default (measured ~3.4s per unreachable queue instead of ~1ms), so a single misconfigured/down queue no longer stalls these admin pages.
- New `SCHEDULER_CONFIG.FAIL_FAST_QUEUE_PROBING` (default `True`) lets users opt out globally, and `SCHEDULER_CONFIG.QUEUE_PROBE_SOCKET_CONNECT_TIMEOUT` (default `2.0`) controls the timeout. Documented in `docs/configuration.md`.
- Single-queue call sites (worker connections, `@job`/`.delay()`, task admin, job/queue actions) are unaffected — only the "sweep every queue" call sites opt in to fail-fast.
- Removed the permanent, process-local `_QUEUES_WITH_BAD_CONFIGURATION` (`views/helpers.py`) and `_BAD_QUEUE_CONFIGURATION` (`helpers/queues/getters.py`) caches. They never expired and were inconsistent across worker processes, so a transiently-down queue stayed marked bad until restart. With fail-fast connections, re-probing a bad queue on every request is cheap, so the cache is no longer needed.

Fixes #378

## Test plan
- [x] `uv run python manage.py test --exclude-tag multiprocess scheduler` — 315 tests pass
- [x] New `scheduler/tests/test_queue_getters.py` covers: defaults injected when absent, user-configured `CONNECTION_KWARGS` respected, global opt-out via `FAIL_FAST_QUEUE_PROBING=False`, and that an unreachable queue fails in well under a second with fail-fast enabled
- [x] `ruff check` / `ruff format --check` / `mypy scheduler/` — no new issues vs. master

🤖 Generated with [Claude Code](https://claude.com/claude-code)