### PR TITLE
Reduce pre-commit.ci PR noise with monthly autoupdate schedule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -17,7 +20,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ build.targets.wheel.include = [ "scheduler" ]
 build.targets.sdist.include = [ "scheduler" ]
 
 [tool.ruff]
-target-version = "py310"
 line-length = 120
 exclude = [ ".venv", "__pycache__", "scheduler/migrations", "testproject" ]
 lint.extend-ignore = [


### PR DESCRIPTION
## Description

- Add `ci.autoupdate_schedule: monthly` to reduce pre-commit.ci PR noise.  [See](https://pre-commit.ci/#configuration-autoupdate_schedule)
- Bump ruff-pre-commit to `v0.16.0` to match the ruff version already
  pinned in the project
- drop redundant ruff target-version (by default it will use `pyproject.toml -> requires-python`)