### PR TITLE
Remove deprecated license classifier from packaging configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Description

See: https://peps.python.org/pep-0639/#deprecate-license-classifiers