### PR TITLE
Avoid FileNotFoundError from temp file cleanup on python 3.11

### DIFF
--- a/scheduler/tests/test_mgmt_commands/test_export.py
+++ b/scheduler/tests/test_mgmt_commands/test_export.py
@@ -15,7 +15,10 @@ from scheduler.tests.testtools import task_factory
 class ExportTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.tmpfile = tempfile.NamedTemporaryFile()
+        # tearDown removes the file itself. With delete=True (The default behaviour), __del__ unlinks it a
+        # second time and python<3.12 dumps that FileNotFoundError to stderr.
+        # https://github.com/python/cpython/blob/3.11/Lib/tempfile.py#L463
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/scheduler/tests/test_mgmt_commands/test_import.py
+++ b/scheduler/tests/test_mgmt_commands/test_import.py
@@ -14,7 +14,10 @@ from scheduler.tests.testtools import task_factory
 
 class ImportTest(TestCase):
     def setUp(self) -> None:
-        self.tmpfile = tempfile.NamedTemporaryFile(mode="w")
+        # tearDown removes the file itself. With delete=True (The default behaviour), __del__ unlinks it a
+        # second time and python<3.12 dumps that FileNotFoundError to stderr.
+        # https://github.com/python/cpython/blob/3.11/Lib/tempfile.py#L463
+        self.tmpfile = tempfile.NamedTemporaryFile(mode="w", delete=False)
 
     def tearDown(self) -> None:
         os.remove(self.tmpfile.name)


### PR DESCRIPTION
## Description

Fixes the CI job failure on Python 3.11 --> https://github.com/django-commons/django-tasks-scheduler/actions/runs/30821905364/job/91982038897#step:9:1126

### Summary

- `tempfile.NamedTemporaryFile()` uses `delete=True` by default.
- The temporary file was being deleted manually during the tests and then being deleted again during cleanup in `__del__()`
- Python 3.11 does not ignore `FileNotFoundError` during cleanup, while newer Python versions do. See: [Lib/tempfile.py#L459](https://github.com/python/cpython/blob/58c86ab1b403dba7595b83695f959b7b49e6eaa9/Lib/tempfile.py#L459)
- Added `delete=False` so that `tearDown()` is only responsible for cleaning up the temporary file.