### PR TITLE
fix(worker): close DB connections before forking a job execution process

### DIFF
--- a/scheduler/helpers/db.py
+++ b/scheduler/helpers/db.py
@@ -1,0 +1,40 @@
+"""Django database connection handling for the worker.
+
+The worker runs each job in a forked child, and a forked child must not inherit an open
+Django DB connection. Parent and child would hold the same socket, and a TLS-wrapped
+stream - the default on a managed Postgres or MySQL - breaks as soon as both use it: the
+first child's queries advance the TLS stream state server-side, and every later child
+starts from the parent's now-stale in-memory TLS state and dies on its first query with
+an opaque transport error such as
+``consuming input failed: SSL error: unexpected eof while reading``.
+
+``scheduler_worker`` closes connections once at startup for this reason, but any ORM call
+the worker makes afterwards opens a new one - notably the failure callbacks that
+``Queue.clean_registries`` runs for abandoned jobs, which read and save ``Task`` rows in
+the worker process itself. Nothing closes that connection again, so one maintenance pass
+can leave every job that follows failing until the worker is restarted.
+
+Django's connection handler is thread-local, so this closes the calling thread's
+connections and leaves the scheduler thread's own connection alone. Closing is cheap:
+whichever process needs the database next opens a fresh connection.
+"""
+
+from django.db import connections
+
+from scheduler.settings import logger
+
+
+def close_db_connections() -> None:
+    """Close the calling thread's Django DB connections.
+
+    ``connections.close_all()`` does the same loop but stops at the first connection that
+    raises, and closing a connection whose socket is already broken can raise - which is
+    one of the states this exists to clear. A connection we cannot close must not stop the
+    remaining ones closing, nor stop the caller forking.
+    """
+    for connection in connections.all(initialized_only=True):
+        try:
+            connection.close()
+        except Exception:
+            # A connection we cannot close must not stop the caller forking.
+            logger.warning(f"Could not close DB connection {connection.alias}", exc_info=True)

--- a/scheduler/management/commands/scheduler_worker.py
+++ b/scheduler/management/commands/scheduler_worker.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import click
 from django.core.management.base import BaseCommand
-from django.db import connections
 
+from scheduler.helpers.db import close_db_connections
 from scheduler.settings import logger
 from scheduler.types import ConnectionErrorTypes
 from scheduler.worker import create_worker
@@ -31,11 +31,6 @@ WORKER_ARGUMENTS = {
     "with_scheduler",
     "burst",
 }
-
-
-def reset_db_connections() -> None:
-    for c in connections.all():
-        c.close()
 
 
 def register_sentry(sentry_dsn: str, **opts: Any) -> None:
@@ -145,8 +140,9 @@ class Command(BaseCommand):
             # Instantiate a worker
             w = create_worker(*queues, **init_options)
 
-            # Close any opened DB connection before any fork
-            reset_db_connections()
+            # Close any opened DB connection before any fork. The worker closes them again
+            # before each fork, so an ORM call made while working cannot reach a child.
+            close_db_connections()
 
             # Check whether sentry is enabled
             if options.get("sentry_dsn") is not None:

--- a/scheduler/tests/test_worker/test_db_connections.py
+++ b/scheduler/tests/test_worker/test_db_connections.py
@@ -1,0 +1,198 @@
+"""The worker process must hold no open Django DB connection when it forks a job child.
+
+A child that inherits one shares the parent's socket. See scheduler.helpers.db for the
+full mechanism and what it costs in production.
+
+Two things shape how these tests are written:
+
+* django.test.TestCase wraps each test in a transaction, which keeps a connection open for
+  the whole test and makes closing one impossible to observe, so these use
+  TransactionTestCase.
+* Django deliberately ignores close() on an in-memory database, which is what the test
+  database is, so `connection.connection is None` can never be observed here. Instead each
+  test records whether a connection was live at the moment the worker closed it, which is
+  the state the fork depends on.
+"""
+
+import threading
+from unittest import mock
+
+from django.db import connections
+from django.test import TransactionTestCase
+
+from scheduler.helpers.callback import Callback
+from scheduler.helpers.db import close_db_connections
+from scheduler.helpers.queues import get_queue
+from scheduler.helpers.utils import current_timestamp
+from scheduler.models import Task, TaskType
+from scheduler.models.task import failure_callback
+from scheduler.tests import conf  # noqa: F401
+from scheduler.tests.jobs import test_job
+from scheduler.tests.testtools import task_factory
+from scheduler.worker import create_worker
+
+
+class WorkerDbConnectionTestCase(TransactionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.queue = get_queue("default")
+        self.queue.connection.flushall()
+        self.events: list[str] = []
+
+    def _worker(self, name: str):
+        worker = create_worker("default", name=name, with_scheduler=False)
+        worker.worker_start()
+        return worker
+
+    def _watch_closes(self):
+        """Record each close of the default connection, and whether it had a live socket.
+
+        The real close still runs. "live" is the part that matters: it says the worker was
+        holding a usable connection at that moment, which is what a child would inherit.
+        """
+        real_close = connections["default"].close
+
+        def close_and_record() -> None:
+            self.events.append("closed-a-live-connection" if connections["default"].connection else "closed-nothing")
+            real_close()
+
+        return mock.patch.object(connections["default"], "close", close_and_record)
+
+    def _fork_returning_a_child_pid(self):
+        """Stand in for os.fork, returning a pid so the parent branch runs.
+
+        A real fork here would duplicate the test runner.
+        """
+
+        def fork() -> int:
+            self.events.append("forked")
+            return 4242
+
+        return mock.patch("scheduler.worker.worker.os.fork", fork)
+
+
+class TestForkingAJobExecutionProcess(WorkerDbConnectionTestCase):
+    def test_the_workers_db_connection_is_closed_before_the_fork(self):
+        job = self.queue.create_and_enqueue_job(test_job)
+        worker = self._worker("test-fork-db-connections")
+        Task.objects.count()  # the worker's thread now owns a real DB connection
+
+        with self._watch_closes(), self._fork_returning_a_child_pid():
+            worker.fork_job_execution_process(job, self.queue)
+
+        self.assertEqual(
+            ["closed-a-live-connection", "forked"],
+            self.events,
+            "the child inherits the parent's connection object and its socket, and every child "
+            "after the first then fails on its first query",
+        )
+
+    def test_a_connection_that_will_not_close_does_not_stop_the_worker_forking(self):
+        # Closing a connection whose socket is already broken can raise, and that is one of
+        # the states this is here to clear.
+        job = self.queue.create_and_enqueue_job(test_job)
+        worker = self._worker("test-fork-db-close-raises")
+        Task.objects.count()
+
+        with (
+            mock.patch.object(connections["default"], "close", side_effect=OSError("broken socket")),
+            self._fork_returning_a_child_pid(),
+        ):
+            worker.fork_job_execution_process(job, self.queue)
+
+        self.assertEqual(["forked"], self.events, "a connection that will not close must not stop the job running")
+
+
+class TestMaintenanceThatRunsAFailureCallback(WorkerDbConnectionTestCase):
+    def _enqueue_an_abandoned_job_for(self, task: Task):
+        """Enqueue a job for `task`, registered as active long enough ago to count as abandoned."""
+        job = self.queue.create_and_enqueue_job(
+            test_job,
+            timeout=60,
+            on_failure=Callback(failure_callback),
+            task_type=task.task_type,
+            scheduled_task_id=task.id,
+        )
+        self.queue.active_job_registry.add(self.queue.connection, job.name, current_timestamp() - 3600)
+        return job
+
+    def test_the_connection_the_failure_callback_opened_is_closed_again(self):
+        task = task_factory(TaskType.ONCE)
+        self._enqueue_an_abandoned_job_for(task)
+        worker = self._worker("test-maintenance-db-connections")
+        connections["default"].close()
+
+        with self._watch_closes():
+            worker.run_maintenance_tasks()
+
+        task.refresh_from_db()
+        self.assertEqual(1, task.failed_runs, "test setup: the ORM failure callback did not run")
+        self.assertEqual(
+            ["closed-a-live-connection"],
+            self.events,
+            "the maintenance pass ran a Django ORM failure callback in the worker process and left "
+            "its connection open, so every job child forked afterwards inherits it",
+        )
+
+    def test_the_connection_is_closed_even_when_the_failure_callback_raises(self):
+        task = task_factory(TaskType.ONCE)
+        self._enqueue_an_abandoned_job_for(task)
+        worker = self._worker("test-maintenance-db-raises")
+
+        with (
+            self._watch_closes(),
+            mock.patch("scheduler.models.task.mail_admins", side_effect=ValueError("mail server down")),
+            self.assertRaises(ValueError),
+        ):
+            worker.run_maintenance_tasks()
+
+        self.assertEqual(
+            ["closed-a-live-connection"],
+            self.events,
+            "clean_registries re-raises a failing failure callback, and the connection that callback "
+            "opened has to be released either way",
+        )
+
+
+class TestCloseDbConnections(WorkerDbConnectionTestCase):
+    def test_another_threads_connection_is_left_open_and_usable(self):
+        # The scheduler runs in its own thread off its own connection. Django's connection
+        # handler is thread-local and this fix depends on that: closing the worker's
+        # connections must not disturb the scheduler mid-query.
+        scheduler_has_connected = threading.Event()
+        worker_has_closed = threading.Event()
+        scheduler: dict = {}
+
+        def scheduler_thread() -> None:
+            try:
+                Task.objects.count()
+                scheduler["connection_before"] = connections["default"].connection
+                scheduler_has_connected.set()
+                worker_has_closed.wait(timeout=10)
+                scheduler["connection_after"] = connections["default"].connection
+                scheduler["task_count"] = Task.objects.count()
+            except BaseException as e:
+                scheduler["error"] = e  # reported as a test failure below
+            finally:
+                scheduler_has_connected.set()
+                connections["default"].close()
+
+        task_factory(TaskType.ONCE)
+        thread = threading.Thread(target=scheduler_thread, name="scheduler-thread")
+        thread.start()
+        self.assertTrue(scheduler_has_connected.wait(timeout=10), "test setup: scheduler thread never started")
+
+        Task.objects.count()  # the worker's own connection
+        with self._watch_closes():
+            close_db_connections()
+        worker_has_closed.set()
+        thread.join(timeout=10)
+
+        self.assertIsNone(scheduler.get("error"), f"scheduler thread failed: {scheduler.get('error')}")
+        self.assertEqual(["closed-a-live-connection"], self.events, "the worker's own connection was not closed")
+        self.assertIs(
+            scheduler["connection_before"],
+            scheduler["connection_after"],
+            "the scheduler thread's connection should be untouched",
+        )
+        self.assertEqual(1, scheduler["task_count"], "the scheduler thread should still be able to query")

--- a/scheduler/worker/worker.py
+++ b/scheduler/worker/worker.py
@@ -32,6 +32,7 @@ from scheduler.types import (
     WatchErrorTypes,
 )
 
+from ..helpers.db import close_db_connections
 from ..helpers.queues.getters import get_queue_connection
 from ..redis_models.lock import QueueLock
 from ..redis_models.worker import WorkerStatus
@@ -341,7 +342,13 @@ class Worker:
         1. Check if scheduler should be started.
         2. Cleaning registries
         """
-        self.clean_registries()
+        try:
+            self.clean_registries()
+        finally:
+            # Abandoned jobs' failure callbacks run here, in this process, and are Django ORM
+            # (scheduler.models.task.failure_callback), so this pass can leave the worker
+            # holding a connection that the next fork would inherit.
+            close_db_connections()
         if not self.with_scheduler:
             return
         if self.scheduler is None and self.with_scheduler:
@@ -562,6 +569,9 @@ class Worker:
         :param job: The job to be executed
         :param queue: The queue from which the job was dequeued
         """
+        # The child must not inherit an open Django DB connection - see
+        # scheduler.helpers.db.close_db_connections for what happens when it does.
+        close_db_connections()
         child_pid = os.fork()
         os.environ["SCHEDULER_WORKER_NAME"] = self.name
         os.environ["SCHEDULER_JOB_NAME"] = job.name


### PR DESCRIPTION
fixes #393 

The worker runs each job in a forked child, and `scheduler_worker` closes Django's DB connections once at boot for that reason ("Close any opened DB connection before any fork"). Nothing keeps that true afterwards.

`Worker.run_maintenance_tasks` -> `Queue.clean_registries` runs the failure callback of every abandoned job in the worker process itself, and for a `Task` that callback is Django ORM: `scheduler.models.task.failure_callback` reads the `Task` row and saves it. The worker now holds a connection, and every child inherits the connection object together with its socket. The first child can use it; on a TLS-wrapped connection (the default for a managed Postgres or MySQL) that advances the stream state server-side, and every later child inherits stale in-memory TLS state and fails on its first query with an opaque transport error such as

    OperationalError: consuming input failed: SSL error: unexpected eof while reading

Nothing in the package closes connections on any job or maintenance path, so there is no recovery: every job then fails in milliseconds until the worker is restarted. Abandoned jobs are what a killed or wedged worker leaves behind, so the cleanup meant to tidy up after one failure is what causes the next.

Add `scheduler.helpers.db.close_db_connections` and call it immediately before `os.fork()`, and after the maintenance pass that can open one. It closes the calling thread's connections only, so the scheduler thread's own connection is untouched, and skips uninitialized aliases so no connection is opened just to be closed. Each connection is closed independently because `close()` can raise for a connection whose socket is already broken - one of the states this exists to clear - and that must not stop the worker forking.