### PR TITLE
fix(queue): score queued jobs with the enqueue time, not the registry max

### DIFF
--- a/scheduler/helpers/queues/queue_logic.py
+++ b/scheduler/helpers/queues/queue_logic.py
@@ -418,7 +418,7 @@ class Queue:
             if at_front:
                 score = current_timestamp()
             else:
-                score = self.queued_job_registry.get_last_timestamp(self.connection) or current_timestamp()
+                score = current_timestamp()
             self.scheduled_job_registry.delete(connection=pipe, job_name=job_model.name)
             self.queued_job_registry.add(connection=pipe, score=score, job_name=job_model.name)
             pipe.execute()

--- a/scheduler/tests/test_internals.py
+++ b/scheduler/tests/test_internals.py
@@ -6,7 +6,12 @@ from django.test import override_settings
 from django.utils import timezone
 
 from scheduler.helpers.callback import Callback, CallbackSetupError
+from scheduler.helpers.queues import get_queue
+from scheduler.helpers.utils import current_timestamp
 from scheduler.models import TaskType, get_next_cron_time, get_scheduled_task
+from scheduler.redis_models import QueuedJobRegistry
+from scheduler.tests import conf  # noqa
+from scheduler.tests.jobs import test_job
 from scheduler.tests.testtools import SchedulerBaseCase, task_factory
 
 
@@ -45,6 +50,23 @@ class TestInternals(SchedulerBaseCase):
         with self.assertRaises(CallbackSetupError) as cm:
             Callback(1)
         self.assertEqual(str(cm.exception), "Callback `func` must be a string or function, received 1")
+
+
+class TestEnqueueJobScore(SchedulerBaseCase):
+    def test_enqueue_job__score_is_current_time_not_registry_max(self):
+        # arrange
+        queue = get_queue("default")
+        registry = queue.queued_job_registry
+        first_job = queue.create_and_enqueue_job(test_job, name="z-job-enqueued-first")
+        registry.add(queue.connection, first_job.name, current_timestamp() - 100)
+        # act
+        enqueue_time = current_timestamp()
+        second_job = queue.create_and_enqueue_job(test_job, name="a-job-enqueued-second")
+        # assert
+        self.assertGreaterEqual(queue.connection.zscore(registry.key, second_job.name), enqueue_time)
+        _, first_dequeued = QueuedJobRegistry.pop(queue.connection, [registry], timeout=None)
+        _, second_dequeued = QueuedJobRegistry.pop(queue.connection, [registry], timeout=None)
+        self.assertEqual([first_job.name, second_job.name], [first_dequeued, second_dequeued])
 
 
 class TestConfSettings(SchedulerBaseCase):


### PR DESCRIPTION
`enqueue_job` scored a queued job with the highest score already in the queued registry, so the score never advanced while the queue was non-empty and every job landed on the same value. `bzpopmin` then broke ties lexicographically by member name, draining the queue in task-id-as-string order instead of FIFO, and a late-sorting task could starve for as long as the queue held an earlier-sorting member.

Score with the current time instead. Jobs that tie within the same second became due together, so their relative order was never meaningful — what broke the queue was a score that never advanced at all. The `at_front` arm is left as is; its own defect is #398.

Closes #397