### PR TITLE
fix(queue): score at_front jobs below the current queue minimum

### DIFF
--- a/scheduler/helpers/queues/queue_logic.py
+++ b/scheduler/helpers/queues/queue_logic.py
@@ -416,7 +416,8 @@ class Queue:
 
         if self._is_async:
             if at_front:
-                score = current_timestamp()
+                first = self.connection.zrange(self.queued_job_registry.key, 0, 0, withscores=True)
+                score = int(first[0][1]) - 1 if first else current_timestamp()
             else:
                 score = self.queued_job_registry.get_last_timestamp(self.connection) or current_timestamp()
             self.scheduled_job_registry.delete(connection=pipe, job_name=job_model.name)

--- a/scheduler/tests/test_redis_models.py
+++ b/scheduler/tests/test_redis_models.py
@@ -2,7 +2,8 @@ from django.urls import reverse
 
 from scheduler import settings
 from scheduler.helpers.queues import get_queue
-from scheduler.redis_models import Result, ResultType
+from scheduler.redis_models import JobNamesRegistry, Result, ResultType
+from scheduler.tests import conf  # noqa
 from scheduler.tests.jobs import failing_job, test_job
 from scheduler.tests.testtools import SchedulerBaseCase
 
@@ -102,6 +103,20 @@ class TestResult(SchedulerBaseCase):
             settings.SCHEDULER_CONFIG.DEFAULT_FAILURE_TTL,
             queue.connection.ttl(Result._children_key_template.format(job.name)),
         )
+
+
+class TestQueuedJobRegistry(SchedulerBaseCase):
+    def test_enqueue_job_at_front__dequeued_first(self):
+        # arrange
+        queue = get_queue("default")
+        normal_job = queue.create_and_enqueue_job(test_job)
+        # act
+        at_front_job = queue.create_and_enqueue_job(test_job, at_front=True)
+        # assert
+        scores = dict(queue.queued_job_registry.all_with_timestamps(queue.connection))
+        self.assertLess(scores[at_front_job.name], scores[normal_job.name])
+        _, job_name = JobNamesRegistry.pop(queue.connection, [queue.queued_job_registry], None)
+        self.assertEqual(at_front_job.name, job_name)
 
 
 class TestQueueAdmin(SchedulerBaseCase):


### PR DESCRIPTION
`enqueue_job(at_front=True)` scored the job with `current_timestamp()`, the largest score in the registry, while the worker pops the smallest — so an at-front job was dequeued last, not first.

Give it a score just below the current minimum instead, falling back to the current time on an empty registry. The read goes through `self.connection` — the buffering pipeline would return itself rather than data. Successive at-front jobs decrement by one and are LIFO among themselves.

Closes #398