### PR TITLE
fix(scheduler): remove registry entries whose job model is gone

### DIFF
--- a/scheduler/helpers/queues/queue_logic.py
+++ b/scheduler/helpers/queues/queue_logic.py
@@ -131,7 +131,10 @@ class Queue:
 
         for job_name, job_score in started_jobs:
             job = JobModel.get(job_name, connection=self.connection)
-            if job is None or not job.has_failure_callback or job_score + job.timeout > before_score:
+            if job is None:
+                self.active_job_registry.delete(connection=self.connection, job_name=job_name)
+                continue
+            if not job.has_failure_callback or job_score + job.timeout > before_score:
                 continue
 
             logger.debug(f"Running failure callbacks for {job.name}")

--- a/scheduler/tests/test_internals.py
+++ b/scheduler/tests/test_internals.py
@@ -6,6 +6,8 @@ from django.test import override_settings
 from django.utils import timezone
 
 from scheduler.helpers.callback import Callback, CallbackSetupError
+from scheduler.helpers.queues import get_queue
+from scheduler.helpers.utils import current_timestamp
 from scheduler.models import TaskType, get_next_cron_time, get_scheduled_task
 from scheduler.tests.testtools import SchedulerBaseCase, task_factory
 
@@ -45,6 +47,16 @@ class TestInternals(SchedulerBaseCase):
         with self.assertRaises(CallbackSetupError) as cm:
             Callback(1)
         self.assertEqual(str(cm.exception), "Callback `func` must be a string or function, received 1")
+
+
+class TestCleanRegistries(SchedulerBaseCase):
+    def test_active_registry_entry_without_job_is_removed(self):
+        queue = get_queue("default")
+        queue.active_job_registry.add(queue.connection, "orphan-job-name", current_timestamp() - 3600)
+
+        queue.clean_registries()
+
+        self.assertFalse(queue.active_job_registry.exists(queue.connection, "orphan-job-name"))
 
 
 class TestConfSettings(SchedulerBaseCase):

--- a/scheduler/tests/test_worker/test_scheduler.py
+++ b/scheduler/tests/test_worker/test_scheduler.py
@@ -3,7 +3,9 @@ from datetime import timedelta
 import time_machine
 from django.utils import timezone
 
+from scheduler.helpers.utils import current_timestamp
 from scheduler.models import TaskType
+from scheduler.redis_models import JobModel
 from scheduler.settings import SCHEDULER_CONFIG
 from scheduler.tests.testtools import SchedulerBaseCase, task_factory
 from scheduler.worker import WorkerScheduler, create_worker
@@ -37,3 +39,32 @@ class TestWorkerScheduler(SchedulerBaseCase):
             self.assertIsNotNone(task.job_name)
             self.assertTrue(task.rqueue.queued_job_registry.exists(task.rqueue.connection, task.job_name))
             self.assertFalse(task.rqueue.scheduled_job_registry.exists(task.rqueue.connection, task.job_name))
+
+    def test_scheduler_removes_scheduled_registry_entry_without_job(self):
+        # arrange
+        task = task_factory(TaskType.CRON)
+        job_name = task.job_name
+        self.assertIsNotNone(job_name)
+        connection = task.rqueue.connection
+        registry = task.rqueue.scheduled_job_registry
+        connection.delete(JobModel.key_for(job_name))
+        registry.add(connection, job_name, current_timestamp() - 10)
+
+        scheduler = WorkerScheduler([task.rqueue], worker_name="fake-worker")
+        scheduler._acquire_locks()
+
+        # act
+        scheduler.enqueue_scheduled_jobs()
+
+        # assert
+        self.assertFalse(registry.exists(connection, job_name))
+        self.assertFalse(task.rqueue.queued_job_registry.exists(connection, job_name))
+
+        # act: the next pass schedules the task again
+        scheduler.enqueue_scheduled_jobs()
+
+        # assert
+        task.refresh_from_db()
+        self.assertIsNotNone(task.job_name)
+        self.assertNotEqual(job_name, task.job_name)
+        self.assertTrue(registry.exists(connection, task.job_name))

--- a/scheduler/worker/scheduler.py
+++ b/scheduler/worker/scheduler.py
@@ -148,9 +148,11 @@ class WorkerScheduler:
             queue = get_queue(registry.name)
             jobs = JobModel.get_many(job_names, connection=self.connection)
             with self.connection.pipeline() as pipeline:
-                for job in jobs:
+                for job_name, job in zip(job_names, jobs):
                     if job is not None:
                         queue.enqueue_job(job, pipeline=pipeline, at_front=job.at_front)
+                    else:
+                        registry.delete(connection=pipeline, job_name=job_name)
                 pipeline.execute()
         self.status = SchedulerStatus.STARTED
 


### PR DESCRIPTION
A name in the scheduled registry whose `JobModel` is gone (Redis eviction, manual deletion) was re-read on every scheduler pass and skipped without ever being removed, while `Task.is_scheduled()` kept answering True on membership alone — so the task was never scheduled again, silently and permanently.

Remove the name when its job fails to load, in the same pipeline the pass already uses; `JobModel.get_many` preserves order with `None` placeholders, so the zip lines up. `clean_registries` gets the same treatment for the active registry. This is safe because a waiting job carries no expiry: `JobModel.expire()` is only called after execution or an explicit delete, so a missing model never means a legitimately waiting job.

Closes #399