### PR TITLE
fix(registry): make QueuedJobRegistry.empty() drain past 1001 jobs

### DIFF
--- a/scheduler/redis_models/registry/queue_registries.py
+++ b/scheduler/redis_models/registry/queue_registries.py
@@ -26,14 +26,15 @@ class QueuedJobRegistry(JobNamesRegistry):
                 self.delete(connection=connection, job_name=job_name)
 
     def empty(self, connection: ConnectionType) -> None:
-        queued_jobs_count = self.count(connection=connection)
-        with connection.pipeline() as pipe:
-            for offset in range(0, queued_jobs_count, 1000):
-                job_names = self.all(connection, offset, 1000)
+        while True:
+            job_names = self.all(connection, 0, 999)
+            if not job_names:
+                return
+            with connection.pipeline() as pipe:
                 for job_name in job_names:
                     self.delete(connection=pipe, job_name=job_name)
                 JobModel.delete_many(job_names, connection=pipe)
-            pipe.execute()
+                pipe.execute()
 
 
 class FinishedJobRegistry(JobNamesRegistry):

--- a/scheduler/tests/test_redis_models.py
+++ b/scheduler/tests/test_redis_models.py
@@ -104,6 +104,20 @@ class TestResult(SchedulerBaseCase):
         )
 
 
+class TestQueuedJobRegistry(SchedulerBaseCase):
+    def test_empty__more_than_1001_jobs__registry_emptied(self):
+        # arrange
+        queue = get_queue("default")
+        registry = queue.queued_job_registry
+        connection = queue.connection
+        connection.zadd(registry.key, {f"job-{i}": float(i) for i in range(1005)})
+        self.assertEqual(1005, registry.count(connection))
+        # act
+        registry.empty(connection)
+        # assert
+        self.assertEqual(0, registry.count(connection))
+
+
 class TestQueueAdmin(SchedulerBaseCase):
     def test_admin_list_view(self):
         # arrange


### PR DESCRIPTION
`empty()` passed its offset to `zrange` as a start rank with a literal 1000 end rank, and buffered every delete in a pipeline executed only after the loop — so only the first 1001 jobs were ever removed, silently.

Drain from the front instead: read a batch of up to 1000 names, delete them and their job models, repeat until the registry is empty. No offset arithmetic, and the deletes take effect between batches, so it cannot drift out of step with concurrent writers.

Closes #400