### PR TITLE
fix(admin): stop posting job_names from registry action confirmations

### DIFF
--- a/scheduler/templates/admin/scheduler/confirm_action.html
+++ b/scheduler/templates/admin/scheduler/confirm_action.html
@@ -30,9 +30,11 @@
         <form action="{{ action_url }}" method="post">
             {% csrf_token %}
             <div>
-                {% for job in jobs %}
-                    <input type="hidden" name="job_names" value="{{ job.name }}">
-                {% endfor %}
+                {% if post_job_names %}
+                    {% for job in jobs %}
+                        <input type="hidden" name="job_names" value="{{ job.name }}">
+                    {% endfor %}
+                {% endif %}
                 <input type="hidden" name="action" value="{{ action }}"/>
                 <input type="hidden" name="next_url" value="{{ next_url }}"/>
                 <input type="submit" value="Yes, I'm sure"/>

--- a/scheduler/tests/test_views/test_queue_actions.py
+++ b/scheduler/tests/test_views/test_queue_actions.py
@@ -1,3 +1,6 @@
+import re
+
+from django.test import override_settings
 from django.urls import reverse
 
 from scheduler.helpers.queues import get_queue
@@ -6,6 +9,14 @@ from scheduler.tests.jobs import failing_job, test_job
 from scheduler.tests.test_views.base import BaseTestCase
 from scheduler.tests.testtools import assert_message_in_response
 from scheduler.worker import create_worker
+
+
+def _hidden_form_fields(content: str) -> dict:
+    """Collect the hidden inputs a browser would submit from a rendered confirmation form"""
+    fields: dict = {}
+    for name, value in re.findall(r'<input type="hidden" name="([^"]+)" value="([^"]*)"', content):
+        fields.setdefault(name, []).append(value)
+    return fields
 
 
 class QueueActionsViewsTest(BaseTestCase):
@@ -77,6 +88,46 @@ class QueueActionsViewsTest(BaseTestCase):
         for job_name in job_names:
             job = JobModel.get(job_name, connection=queue.connection)
             self.assertFalse(job.is_failed)
+
+    @override_settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=10)
+    def test_registry_action_empty__more_jobs_than_max_number_fields(self):
+        queue = get_queue("django_tasks_scheduler_test")
+        for _ in range(20):
+            queue.create_and_enqueue_job(test_job)
+        url = reverse("queue_registry_action", args=[queue.name, "queued", "empty"])
+
+        # render the confirmation page and submit the form fields it contains, as a browser would
+        res = self.client.get(url)
+        self.assertEqual(200, res.status_code)
+        form_data = _hidden_form_fields(res.content.decode())
+        res = self.client.post(url, form_data, follow=True)
+
+        self.assertEqual(200, res.status_code)
+        self.assertNotIn("job_names", form_data)
+        self.assertEqual(0, queue.queued_job_registry.count(queue.connection))
+
+    def test_job_list_confirm_action__renders_job_names(self):
+        queue = get_queue("django_tasks_scheduler_test")
+        job_names = []
+        for _ in range(3):
+            job = queue.create_and_enqueue_job(test_job, job_info_ttl=0)
+            job_names.append(job.name)
+
+        # render the confirmation page for the selected jobs
+        res = self.client.post(
+            reverse("queue_confirm_job_action", args=[queue.name]),
+            {"action": "delete", "_selected_action": job_names},
+        )
+        self.assertEqual(200, res.status_code)
+        form_data = _hidden_form_fields(res.content.decode())
+        self.assertEqual(job_names, form_data["job_names"])
+
+        # submit the form fields it contains, as a browser would
+        res = self.client.post(reverse("queue_job_actions", args=[queue.name]), form_data, follow=True)
+        self.assertEqual(200, res.status_code)
+        for job_name in job_names:
+            self.assertFalse(JobModel.exists(job_name, connection=queue.connection), f"job {job_name} exists")
+            self.assertNotIn(job_name, queue.queued_job_registry.all(queue.connection))
 
     def test_job_list_action_stop_jobs__move_to_finished_registry(self):
         queue_name = "django_tasks_scheduler_test"

--- a/scheduler/views/queue_job_actions.py
+++ b/scheduler/views/queue_job_actions.py
@@ -86,5 +86,6 @@ def queue_confirm_job_action(request: HttpRequest, queue_name: str) -> HttpRespo
                 queue_name,
             ],
         ),
+        "post_job_names": True,
     }
     return render(request, "admin/scheduler/confirm_action.html", context_data)

--- a/scheduler/views/queue_registry_actions.py
+++ b/scheduler/views/queue_registry_actions.py
@@ -74,5 +74,6 @@ def queue_registry_actions(request: HttpRequest, queue_name: str, registry_name:
         "jobs": job_list,
         "next_url": next_url,
         "action_url": reverse("queue_registry_action", args=[queue_name, registry_name, action]),
+        "post_job_names": False,
     }
     return render(request, "admin/scheduler/confirm_action.html", context_data)


### PR DESCRIPTION
The confirmation page for registry actions rendered one hidden `job_names` input per job, so any queue above `DATA_UPLOAD_MAX_NUMBER_FIELDS` (default 1000) made the confirm POST fail with a bare 400 before the view ran — and the posted names were never read: both registry actions enumerate the registry server-side.

Render the inputs only for the per-job actions that consume them, driven by an explicit `post_job_names` context flag. A guard on the action name would not work — `requeue` is a value in both enums. The registry actions also become atomic with respect to jobs enqueued between rendering and confirming.

Closes #401