### PR TITLE
fix(queue): make has_failure_callback a property and sweep registries once

### DIFF
--- a/scheduler/helpers/queues/queue_logic.py
+++ b/scheduler/helpers/queues/queue_logic.py
@@ -148,8 +148,8 @@ class Queue:
                 exc_string = f"Moved to {self.failed_job_registry.key}, due to AbandonedJobError, at {utcnow()}"
                 self.job_handle_failure(JobStatus.FAILED, job, exc_string)
 
-            for registry in self.REGISTRIES.values():
-                getattr(self, registry).cleanup(connection=self.connection, timestamp=before_score)
+        for registry in self.REGISTRIES.values():
+            getattr(self, registry).cleanup(connection=self.connection, timestamp=before_score)
 
     def first_queued_job_name(self) -> str | None:
         return self.queued_job_registry.get_first(self.connection)

--- a/scheduler/redis_models/job.py
+++ b/scheduler/redis_models/job.py
@@ -104,6 +104,7 @@ class JobModel(HashModel):
     def is_scheduled_task(self) -> bool:
         return self.scheduled_task_id is not None
 
+    @property
     def has_failure_callback(self) -> bool:
         return self.failure_callback_name is not None
 

--- a/scheduler/tests/test_redis_models.py
+++ b/scheduler/tests/test_redis_models.py
@@ -1,7 +1,9 @@
 from django.urls import reverse
 
 from scheduler import settings
+from scheduler.helpers.callback import Callback
 from scheduler.helpers.queues import get_queue
+from scheduler.helpers.utils import current_timestamp
 from scheduler.redis_models import Result, ResultType
 from scheduler.tests.jobs import failing_job, test_job
 from scheduler.tests.testtools import SchedulerBaseCase
@@ -102,6 +104,47 @@ class TestResult(SchedulerBaseCase):
             settings.SCHEDULER_CONFIG.DEFAULT_FAILURE_TTL,
             queue.connection.ttl(Result._children_key_template.format(job.name)),
         )
+
+
+class TestJobModelHasFailureCallback(SchedulerBaseCase):
+    def test_job_without_failure_callback__has_failure_callback_is_false(self):
+        # arrange
+        queue = get_queue("default")
+        # act
+        job = queue.create_and_enqueue_job(test_job)
+        # assert
+        self.assertIs(False, job.has_failure_callback)
+
+    def test_job_with_failure_callback__has_failure_callback_is_true(self):
+        # arrange
+        queue = get_queue("default")
+        # act
+        job = queue.create_and_enqueue_job(failing_job, on_failure=Callback(test_job))
+        # assert
+        self.assertIs(True, job.has_failure_callback)
+
+
+class TestQueueCleanRegistries(SchedulerBaseCase):
+    def test_no_abandoned_jobs__expired_registry_entries_are_swept(self):
+        # arrange
+        queue = get_queue("default")
+        registry = queue.finished_job_registry
+        registry.add(queue.connection, "expired-job", current_timestamp() - 100)
+        self.assertTrue(registry.exists(queue.connection, "expired-job"))
+        # act
+        queue.clean_registries()
+        # assert
+        self.assertFalse(registry.exists(queue.connection, "expired-job"))
+
+    def test_abandoned_job_without_failure_callback__not_moved_to_failed_registry(self):
+        # arrange
+        queue = get_queue("default")
+        job = queue.create_and_enqueue_job(test_job, timeout=60)
+        queue.active_job_registry.add(queue.connection, job.name, current_timestamp() - 3600)
+        # act
+        queue.clean_registries()
+        # assert
+        self.assertFalse(queue.failed_job_registry.exists(queue.connection, job.name))
 
 
 class TestQueueAdmin(SchedulerBaseCase):


### PR DESCRIPTION
`has_failure_callback` was a plain method read as an attribute, so the abandoned-job guard in `clean_registries` was always truthy and did nothing; the registry sweep at the end of the same function was nested inside the per-job loop and never ran in the common case.

Add the missing `@property` and dedent the sweep so it runs once per call. This makes the guard real: abandoned jobs without a failure callback are no longer moved to the failed registry — see the issue for the trade-off, which deserves a maintainer's judgement.

Closes #402