### PR TITLE
test(worker): wait for the job to start before sending the stop command

### DIFF
--- a/scheduler/tests/test_worker/test_worker_commands.py
+++ b/scheduler/tests/test_worker/test_worker_commands.py
@@ -69,7 +69,10 @@ class WorkerCommandsTest(BaseTestCase):
         # Act
         t = Thread(target=worker.work, args=(0,), name="worker-thread")
         t.start()
-        sleep(0.1)
+        for _ in range(100):
+            if WorkerModel.get(worker.name, connection=queue.connection).current_job_name == job.name:
+                break
+            sleep(0.05)
         command = StopJobCommand(worker_name=worker_name, job_name=job.name)
         command_payload = json.dumps(command.command_payload())
         worker._command_listener.handle_payload({"data": command_payload})


### PR DESCRIPTION
`test_stop_job_command__success` started the worker thread and slept a fixed 100 ms before sending the stop command. When the worker has not picked the job up inside that window — easy on a loaded CI runner — the command finds no matching current job, `stopped_job_name` is never set, and the test fails with `None != '<job name>'`. It did so three times across #403 and #404, on three different brokers, and a no-change re-run passed.

Poll the worker model until it reports the job as current, bounded at five seconds, before sending the stop. Nothing else in the test changes.

Closes #409