### PR TITLE
Prevent duplicate recurring task chains

### DIFF
--- a/.github/workflows/test-cron-ownership.yml
+++ b/.github/workflows/test-cron-ownership.yml
@@ -1,0 +1,50 @@
+name: Cron ownership on PostgreSQL
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cron-ownership:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: scheduler
+          POSTGRES_PASSWORD: scheduler-test
+          POSTGRES_DB: scheduler
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U scheduler"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+      redis:
+        image: redis:8.8.0
+        ports: [6379:6379]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s --health-timeout 5s --health-retries 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.21"
+          python-version: "3.13"
+      - run: uv sync --extra yaml --locked
+      - name: Check cron lifecycle and concurrent transactions
+        working-directory: testproject
+        env:
+          FAKEREDIS: "False"
+        run: >-
+          uv run --with 'psycopg[binary]' python manage.py test
+          --settings=testproject.postgres_settings
+          scheduler.tests.test_task_types.test_completion_errors
+          scheduler.tests.test_task_types.test_cron_ownership
+          scheduler.tests.test_task_types.test_cron_concurrency
+          scheduler.tests.test_task_types.test_cron_scheduler_race

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,22 @@ Three task types are defined in `scheduler/types/`:
 ### Test Infrastructure
 
 Base test class `SchedulerBaseCase` (`scheduler/tests/testtools.py`) sets up queues and FakeRedis. Use `task_factory()` helpers to create Task instances in tests. The `testproject/` directory is a minimal Django project wired to the scheduler app.
+
+### Cron ownership regressions
+
+The default suite runs the cron lifecycle tests against SQLite; concurrency tests
+skip without row-level locking. To exercise PostgreSQL transactions with a real
+broker, start disposable PostgreSQL and Redis services and run from `testproject/`:
+
+```bash
+FAKEREDIS=False BROKER_PORT=6379 PGPORT=5432 uv run --with 'psycopg[binary]' python manage.py test \
+  --settings=testproject.postgres_settings \
+  scheduler.tests.test_task_types.test_cron_ownership \
+  scheduler.tests.test_task_types.test_cron_concurrency
+```
+
+The PostgreSQL test settings accept `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and
+`PGPASSWORD` (defaults: localhost, 5432, scheduler, scheduler, scheduler-test).
+The role must be able to create test databases. Use disposable broker instances:
+test setup flushes their databases. The `Cron ownership on PostgreSQL` workflow
+runs this combination on pull requests.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### 🐛 Bug Fixes
+
+- Stop a scheduler sweep landing in the dequeue handoff window, where the job is briefly in no registry, from
+  starting a second recurring chain #412
+- Retire the old job when a task's queue or type changes, instead of leaving it to run and reschedule itself #412
+- Stop a save from a stale `Task` instance bringing a deleted task back #412
+- Lock the task row for every schedule transition, so two workers cannot both give a task a job #412
+- Keep schedules separate per database alias, so the same task id in two databases keeps both its jobs #412
+- Report an unknown schedule in the admin, rather than a checkmark, when the broker cannot be read; a task save that
+  could not reach the broker now says so instead of reporting success
+- Preserve completed-run counters when scheduling a successor fails because the broker is unavailable
+- Send failure notifications after completion bookkeeping for every task type; mail errors do not undo the run outcome
+
 ## v4.3.0 🌈
 
 ### 🐛 Bug Fixes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -158,3 +158,55 @@ options:
   --skip-checks         Skip system checks.
 
 ```
+
+## `reconcile_scheduler` — Inspect or repair cron schedules
+
+```shell
+python manage.py reconcile_scheduler
+python manage.py reconcile_scheduler --queue default --apply
+python manage.py reconcile_scheduler --database default --apply
+```
+
+The default is a dry run that reports live recurring jobs for each cron task.
+`--apply` adopts an existing recurring owner, removes extra waiting copies, and
+creates a successor if an enabled cron has none. It uses the same task row lock
+as saves and callbacks. Manual runs and started jobs are preserved. A worker
+checks recurring ownership before calling the task, so an obsolete copy already
+removed from the queue cannot start a second chain.
+
+Use a database with row-level locks, such as PostgreSQL, for concurrent schedulers,
+workers and admin writes. SQLite supports sequential use; its `select_for_update`
+is a no-op and does not provide these concurrency guarantees. Database and broker
+updates are separate transactions: a later tick repairs an enqueue whose result
+was lost. This is not a guarantee that business side effects run exactly once.
+
+The automatic sweep queries only the database selected by
+`router.db_for_write(Task)`, normally `default`. Jobs and callbacks retain their
+task's database alias, but the sweep does not visit additional aliases. A cron
+on another alias can therefore lose its recurring chain after a callback broker
+failure. Repair it with `reconcile_scheduler --database other --apply`; automatic
+recovery across all configured databases is not provided by this version.
+
+A queued/started record briefly outside all registries remains the owner during
+worker handoff. If it stays missing, recovery waits its timeout plus 60 seconds
+from the first observation, then replaces it on the next tick. A broker read
+failure does not authorize either execution or another enqueue.
+
+Discovery scans the scheduled, queued and active registries for each cron, in
+batches of up to 1,000 entries. Work grows with both the number of cron tasks and
+the number of queue entries. Measure scheduler tick duration on large queues;
+a per-task membership index is a follow-up optimization for this draft.
+
+### Upgrading existing workers
+
+Old manual jobs have no marker distinguishing them from recurring jobs. Before
+starting this version, stop scheduling, drain queued and active work with the old
+workers, and stop those workers. Draining can execute existing duplicates. Then
+run the inspection command, apply reconciliation, and start the new workers.
+Do not mix old and new scheduler/worker versions during this transition: old
+callbacks can recreate duplicate chains. Scheduled duplicates left after the
+drain can be reconciled by the new version.
+
+Package names, callback import paths and database migrations are unchanged.
+Application-specific database reset and queue purge procedures remain the
+application's responsibility.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,81 @@
+# Testing automatic cron duplication
+
+A normal scheduler sweep can overlap a successful cron execution. Before the
+ownership fix, the sweep loaded whole Task rows and later saved that snapshot.
+If completion advanced the task first, the sweep could restore the old job
+reference and success counter, then create another successor. The callback also
+committed a temporary `job_name=NULL` before creating its successor; a sweep
+could read and later save that temporary state.
+
+`TestCronSchedulerRace` exercises both orderings using PostgreSQL connections and
+real broker registries. It invokes the background `_reschedule_tasks()` path and
+executes the job through `Queue.run_sync()`, including its real success callback
+and completion bookkeeping. Events pause the scheduler after its first SQL read;
+the second test also pauses successor creation until that read completes. These
+timing controls make the race deterministic instead of depending on machine load.
+The tests do not inject stale Task objects or write a missing job reference.
+
+The tests fail on the base revision `13195a3`:
+
+| Sweep reads | Scheduled successors | Successful runs |
+| --- | --- | --- |
+| Before completion | 2 | 0 (rewound from 1) |
+| During successor creation | 2 | 1 |
+| Expected after either ordering | 1 | 1 |
+
+The ownership fix selects fresh task rows under a transaction and row lock.
+Completion uses the same lock, and reconciles the next owner before committing.
+Both tests then pass. PostgreSQL CI runs these tests; SQLite skips them because it
+cannot reproduce the transaction and row-lock behavior.
+
+## Run locally
+
+Use dedicated disposable brokers: the test fixtures call Redis `FLUSHALL`.
+The ports below keep the tests separate from development services on 6379/5432.
+From the repository root:
+
+```sh
+docker run --detach --rm --name scheduler-race-redis \
+  -p 127.0.0.1:16381:6379 redis:8-alpine
+docker run --detach --rm --name scheduler-race-postgres \
+  -p 127.0.0.1:15434:5432 \
+  -e POSTGRES_USER=scheduler -e POSTGRES_PASSWORD=scheduler-test \
+  -e POSTGRES_DB=scheduler postgres:17-alpine
+uv sync --extra yaml --locked
+```
+
+Wait for `docker exec scheduler-race-postgres pg_isready -U scheduler` to succeed.
+Then run from `testproject/`:
+
+```sh
+BROKER_PORT=16381 PGPORT=15434 FAKEREDIS=False \
+  uv run --with 'psycopg[binary]' python manage.py test \
+  --settings=testproject.postgres_settings \
+  scheduler.tests.test_task_types.test_cron_scheduler_race --verbosity=2
+```
+
+## Observe the failing baseline
+
+Keep the current checkout and its test settings, but load the unfixed library
+from a separate worktree. Copy the current test configuration too: the baseline
+configuration ignores `BROKER_PORT` and would connect to port 6379. The regression
+fixture checks the effective port before flushing Redis and fails if it does not
+match `BROKER_PORT`. These copies change only the test harness, not the baseline
+library implementation. From the repository root:
+
+```sh
+SCHEDULER_BASELINE="$(mktemp -d)"
+git worktree add --detach "$SCHEDULER_BASELINE" 13195a3
+cp scheduler/tests/test_task_types/test_cron_scheduler_race.py \
+  "$SCHEDULER_BASELINE/scheduler/tests/test_task_types/"
+cp scheduler/tests/conf.py "$SCHEDULER_BASELINE/scheduler/tests/conf.py"
+cd testproject
+PYTHONPATH="$SCHEDULER_BASELINE" BROKER_PORT=16381 PGPORT=15434 FAKEREDIS=False \
+  uv run --with 'psycopg[binary]' python manage.py test \
+  --settings=testproject.postgres_settings \
+  scheduler.tests.test_task_types.test_cron_scheduler_race --verbosity=2
+```
+
+Expect two assertion failures showing the counts above. Run the same command
+without `PYTHONPATH` to test the fix again. When finished, stop the disposable
+containers with `docker stop scheduler-race-postgres scheduler-race-redis`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,4 +106,5 @@ nav:
   - Configuration: configuration.md
   - Usage: usage.md
   - Management commands: commands.md
+  - Testing cron races: testing.md
   - Change log: changelog.md

--- a/scheduler/admin/task_admin.py
+++ b/scheduler/admin/task_admin.py
@@ -4,6 +4,7 @@ from typing import Any
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.contenttypes.admin import GenericStackedInline
+from django.db import router, transaction
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse
 from django.utils import formats, timezone
@@ -51,6 +52,13 @@ class JobKwargInline(GenericStackedInline):
 def get_message_bit(rows_updated: int) -> str:
     message_bit = "1 task was" if rows_updated == 1 else f"{rows_updated} tasks were"
     return message_bit
+
+
+def _unreachable_broker_message(count: int) -> str:
+    return (
+        f"{get_message_bit(count)} saved, but the broker could not be reached to update the schedule. "
+        "The scheduler will repair it on its next sweep; check the scheduler log."
+    )
 
 
 class JobMethodsDatalistWidget(forms.TextInput):
@@ -206,10 +214,18 @@ class TaskAdmin(admin.ModelAdmin):
 
         return super().change_view(request, object_id, form_url, extra_context=extra)
 
+    def save_model(self, request: HttpRequest, obj: Task, form: Any, change: bool) -> None:
+        super().save_model(request, obj, form, change)
+        if not obj.schedule_updated:
+            self.message_user(request, _unreachable_broker_message(1), messages.WARNING)
+
     def delete_queryset(self, request: HttpRequest, queryset: QuerySet) -> None:
-        for job in queryset:
-            job.unschedule()
-        super().delete_queryset(request, queryset)
+        using = queryset._db or router.db_for_write(queryset.model)
+        queryset = queryset.using(using)
+        with transaction.atomic(using=using):
+            for job in queryset.select_for_update().order_by("pk"):
+                job.unschedule(using=using)
+            super().delete_queryset(request, queryset)
 
     def delete_model(self, request: HttpRequest, obj: Task) -> None:
         obj.unschedule()
@@ -219,8 +235,7 @@ class TaskAdmin(admin.ModelAdmin):
     def disable_selected(self, request: HttpRequest, queryset: QuerySet) -> None:
         rows_updated = 0
         for obj in queryset.filter(enabled=True).iterator():
-            obj.enabled = False
-            obj.unschedule()
+            obj.unschedule(enabled=False)
             rows_updated += 1
 
         level = messages.WARNING if not rows_updated else messages.INFO
@@ -231,13 +246,18 @@ class TaskAdmin(admin.ModelAdmin):
     @admin.action(description=_("Enable selected %(verbose_name_plural)s"), permissions=("change",))
     def enable_selected(self, request: HttpRequest, queryset: QuerySet) -> None:
         rows_updated = 0
+        unreachable = 0
         for obj in queryset.filter(enabled=False).iterator():
             obj.enabled = True
             obj.save()
             rows_updated += 1
+            if not obj.schedule_updated:
+                unreachable += 1
 
         level = messages.WARNING if not rows_updated else messages.INFO
         self.message_user(request, f"{get_message_bit(rows_updated)} successfully enabled and scheduled.", level=level)
+        if unreachable:
+            self.message_user(request, _unreachable_broker_message(unreachable), messages.WARNING)
 
     @admin.action(description="Enqueue now", permissions=("change",))
     def enqueue_job_now(self, request: HttpRequest, queryset: QuerySet) -> None:

--- a/scheduler/helpers/queues/queue_logic.py
+++ b/scheduler/helpers/queues/queue_logic.py
@@ -22,6 +22,7 @@ from scheduler.redis_models import (
     ScheduledJobRegistry,
     SchedulerLock,
 )
+from scheduler.redis_models.job import MISSING_REGISTRY_KEY_PREFIX
 from scheduler.settings import SCHEDULER_CONFIG, logger
 from scheduler.types import ConnectionType, FunctionReferenceType, PipelineType, Self
 
@@ -392,6 +393,7 @@ class Queue:
         while True:
             try:
                 self._remove_from_registries(job_name, connection=pipe)
+                pipe.delete(f"{MISSING_REGISTRY_KEY_PREFIX}{job_name}")
                 self.failed_job_registry.delete(connection=pipe, job_name=job_name)
                 if expire_job_model:
                     job_model = JobModel.get(job_name, connection=self.connection)

--- a/scheduler/management/commands/reconcile_scheduler.py
+++ b/scheduler/management/commands/reconcile_scheduler.py
@@ -1,0 +1,39 @@
+"""Inspect or repair recurring schedules using the same locks as the worker."""
+
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.db import router, transaction
+
+from scheduler.models import Task, TaskType
+from scheduler.models.cron import read_schedule, reconcile
+from scheduler.types.broker_types import BrokerErrorTypes
+
+
+class Command(BaseCommand):  # type: ignore[misc]
+    help = "Inspect cron schedules; --apply adopts one live job and removes waiting duplicates."
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--apply", action="store_true", help="Reconcile schedules under the task row lock")
+        parser.add_argument("--database", help="Task database alias (defaults to the write router)")
+        parser.add_argument("--queue", help="Limit inspection and repair to one queue")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        using = options["database"] or router.db_for_write(Task)
+        tasks = Task.objects.using(using).filter(task_type=TaskType.CRON)
+        if options["queue"]:
+            tasks = tasks.filter(queue=options["queue"])
+        ids = list(tasks.order_by("pk").values_list("pk", flat=True))
+        try:
+            for task_id in ids:
+                with transaction.atomic(using=using):
+                    task = tasks.select_for_update().filter(pk=task_id).first()
+                    if task is None:
+                        continue
+                    schedule = read_schedule(task, task.rqueue)
+                    self.stdout.write(f"{task.pk} {task.name}: {len(schedule.jobs)} live recurring jobs")
+                    if options["apply"] and not reconcile(task):
+                        raise CommandError(f"Could not reconcile {task.name}; check the scheduler log.")
+        except BrokerErrorTypes as exc:
+            raise CommandError(f"Cannot read scheduler state: {exc}") from exc
+        self.stdout.write("Schedules reconciled." if options["apply"] else "Dry run. Add --apply to reconcile.")

--- a/scheduler/models/cron.py
+++ b/scheduler/models/cron.py
@@ -1,0 +1,181 @@
+"""Keep one recurring chain per cron while preserving explicit manual executions.
+
+All schedule transitions lock the Task row before reading Redis. Callbacks run before their
+job leaves the active registry, and dequeue briefly leaves neither queued nor active membership.
+The job record therefore matters as well as registry membership. A missing handoff gets its
+timeout plus 60 seconds from the first observation before replacement. SQL and Redis are not
+atomic: after an ambiguous enqueue the next tick adopts the persisted job rather than creating
+another. Unreadable Redis never authorizes a new enqueue. See django-commons/django-tasks-scheduler#412.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db import models
+from django.utils import timezone
+
+from scheduler.helpers.queues import Queue
+from scheduler.redis_models import JobModel, JobStatus
+from scheduler.redis_models.job import MISSING_REGISTRY_KEY_PREFIX
+from scheduler.types.broker_types import BrokerErrorTypes
+
+if TYPE_CHECKING:
+    from scheduler.models import Task
+
+logger = logging.getLogger(__name__)
+_MANUAL = "scheduler_manual_run"
+_SKIPPED = "scheduler_skipped_duplicate"
+_RUNTIME_FIELDS = (
+    "job_name",
+    "scheduled_time",
+    "successful_runs",
+    "failed_runs",
+    "last_successful_run",
+    "last_failed_run",
+    "created_at",
+)
+_SCHEDULE_FIELDS = ["job_name", "scheduled_time", "updated_at"]
+
+
+def _copy_runtime(source: Task, target: Task) -> None:
+    for field in _RUNTIME_FIELDS:
+        setattr(target, field, getattr(source, field))
+
+
+@dataclass
+class Schedule:
+    jobs: dict[str, JobModel]
+    waiting: set[str]
+    missing: set[str]
+
+
+def read_schedule(task: Task, queue: Queue, exclude: str | None = None) -> Schedule:
+    """Read live recurring jobs without mutating registries or the Task row."""
+    names: set[str] = set()
+    waiting: set[str] = set()
+    scheduled: set[str] = set()
+    for registry in (queue.scheduled_job_registry, queue.queued_job_registry, queue.active_job_registry):
+        members = {
+            name.decode() if isinstance(name, bytes) else name
+            for name, _ in queue.connection.zscan_iter(registry.key, match=f"{task.queue}:{task.pk}:*", count=1000)
+        }
+        names.update(members)
+        if registry is not queue.active_job_registry:
+            waiting.update(members)
+        if registry is queue.scheduled_job_registry:
+            scheduled.update(members)
+    registered = names.copy()
+    if task.job_name:
+        names.add(task.job_name)
+    jobs: dict[str, JobModel] = {}
+    for name in names:
+        if name == exclude:
+            waiting.discard(name)
+            continue
+        job = JobModel.get(name, connection=queue.connection)
+        if job is None:
+            continue
+        if (
+            job.meta.get(_MANUAL)
+            or job.scheduled_task_id != task.pk
+            or job.task_type != task.task_type
+            or job.queue_name != task.queue
+            or job.meta.get("scheduler_task_database", "default") != (task._state.db or "default")
+        ):
+            waiting.discard(name)
+            continue
+        if not same_generation(task, job):
+            continue
+        if job.status in {JobStatus.QUEUED, JobStatus.STARTED} or (
+            job.status == JobStatus.SCHEDULED and name in scheduled
+        ):
+            jobs[name] = job
+    return Schedule(jobs, waiting, set(jobs) - registered)
+
+
+def _expire_lost_handoffs(queue: Queue, schedule: Schedule) -> None:
+    now = timezone.now().timestamp()
+    for name, job in list(schedule.jobs.items()):
+        key = f"{MISSING_REGISTRY_KEY_PREFIX}{name}"
+        if name not in schedule.missing:
+            queue.connection.delete(key)
+            continue
+        # Start the grace period when membership is lost, not when a long-waiting job was enqueued.
+        grace = max(job.timeout, 0) + 60
+        deadline = queue.connection.get(key)
+        if deadline is None:
+            queue.connection.set(key, str(now + grace))
+        elif now > float(deadline):
+            queue.delete_job(name)
+            queue.connection.delete(key)
+            del schedule.jobs[name]
+
+
+def _choose(task: Task, schedule: Schedule) -> str | None:
+    if not task.enabled or not schedule.jobs:
+        return None
+    if task.job_name in schedule.jobs:
+        return str(task.job_name)
+    priority = {JobStatus.STARTED: 0, JobStatus.QUEUED: 1, JobStatus.SCHEDULED: 2}
+    return min(schedule.jobs.values(), key=lambda job: (priority[job.status], job.created_at, job.name)).name
+
+
+def _remove_waiting(queue: Queue, names: set[str]) -> None:
+    for name in sorted(names):
+        job = JobModel.get(name, connection=queue.connection)
+        # A worker can dequeue while we hold the SQL lock; its execution guard handles that copy.
+        if job is not None and (job.status == JobStatus.STARTED or job.meta.get(_MANUAL)):
+            continue
+        queue.delete_job(name)
+
+
+def retire_schedule(task: Task) -> None:
+    """Retire waiting jobs and handoff markers when a task changes identity or is disabled."""
+    queue = task.rqueue
+    schedule = read_schedule(task, queue)
+    _remove_waiting(queue, schedule.waiting)
+    names = schedule.missing | ({task.job_name} if task.job_name else set())
+    for name in names:
+        queue.connection.delete(f"{MISSING_REGISTRY_KEY_PREFIX}{name}")
+
+
+def reconcile(task: Task, *, exclude: str | None = None, create: bool = True) -> bool:
+    """Reconcile one cron while the caller holds its database row lock."""
+    from scheduler.models.task import run_task
+
+    queue = task.rqueue
+    try:
+        schedule = read_schedule(task, queue, exclude)
+        _expire_lost_handoffs(queue, schedule)
+        chosen = _choose(task, schedule)
+        _remove_waiting(queue, schedule.waiting - ({chosen} if chosen else set()))
+        if chosen is None and create and task.enabled:
+            when = task._schedule_time()
+            job = queue.create_and_enqueue_job(
+                run_task,
+                args=(task.task_type, task.pk),
+                when=when,
+                **task._enqueue_args(),
+            )
+            chosen = job.name
+        if task.job_name and task.job_name != chosen:
+            queue.connection.delete(f"{MISSING_REGISTRY_KEY_PREFIX}{task.job_name}")
+        if exclude:
+            queue.connection.delete(f"{MISSING_REGISTRY_KEY_PREFIX}{exclude}")
+        task.job_name = chosen
+        models.Model.save(task, using=task._state.db, update_fields=_SCHEDULE_FIELDS)
+        return True
+    except BrokerErrorTypes:
+        # An ambiguous Redis write may already have created a job. The next tick must adopt it.
+        logger.exception("Could not reconcile cron %s; leaving its schedule unchanged", task.name)
+        return False
+
+
+def same_generation(task: Task, job: JobModel) -> bool:
+    created_at = task.created_at
+    if timezone.is_naive(created_at):
+        created_at = timezone.make_aware(created_at, timezone.get_default_timezone())
+    return bool(job.created_at >= created_at)

--- a/scheduler/models/task.py
+++ b/scheduler/models/task.py
@@ -9,7 +9,7 @@ from django.contrib import admin
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.core.mail import mail_admins
-from django.db import models
+from django.db import models, router, transaction
 from django.db.models import F
 from django.templatetags.tz import utc
 from django.urls import reverse
@@ -20,11 +20,14 @@ from django.utils.translation import gettext_lazy as _
 from scheduler import settings
 from scheduler.helpers.callback import Callback
 from scheduler.helpers.queues import Queue, get_queue
+from scheduler.helpers.queues.queue_logic import get_current_job
 from scheduler.redis_models import JobModel
 from scheduler.settings import get_queue_names, logger
 from scheduler.types import TASK_TYPES, ConnectionType
+from scheduler.types.broker_types import BrokerErrorTypes
 
 from ..helpers import utils
+from . import cron
 from .args import TaskArg, TaskKwarg
 
 # Fields that `_schedule()` may change. Everything that writes back a task it read before a run finished - the
@@ -38,60 +41,51 @@ _SCHEDULING_FIELDS = ("job_name", "scheduled_time", "repeat")
 _RUN_STATE_FIELDS = ("job_name", "successful_runs", "last_successful_run", "failed_runs", "last_failed_run")
 
 
-def _get_task_for_job(job: JobModel) -> Optional["Task"]:
-    if job.task_type is None or job.scheduled_task_id is None:
-        return None
-    task: Task = Task.objects.filter(id=job.scheduled_task_id).first()
-    return task
-
-
-def _complete_run(task: "Task", job: JobModel, failed: bool) -> None:
-    """Record the outcome of a finished job and, when that job owned the task's recurring chain, schedule its
-    successor.
-
-    :param task: The task the job belongs to, read from the database by the caller.
-    :param job: The job that just finished.
-    :param failed: Whether the job failed.
-    """
-    now = timezone.now()
-    if failed:
-        counters: dict[str, Any] = {"failed_runs": F("failed_runs") + 1, "last_failed_run": now}
-    else:
-        counters = {"successful_runs": F("successful_runs") + 1, "last_successful_run": now}
-    # Increment in the database rather than through this instance: another run of the same task may be finishing
-    # concurrently, and a read-modify-write here would drop its result.
-    Task.objects.filter(id=task.id).update(updated_at=now, **counters)
-
-    if task.job_name != job.name:
-        # This job is not the task's pending execution - it is a manual "Enqueue now" run, or a leftover duplicate.
-        # The scheduled job is still waiting, so scheduling a successor here would start a second recurring chain
-        # that then sustains itself forever.
-        logger.debug(f"Job {job.name} is not the scheduled run of task {task.name}, not scheduling a successor")
+def _complete_task(job: JobModel, *, failed: bool) -> None:
+    """Record the outcome of a finished job and, when that job owned the task's chain, schedule its successor."""
+    if job.scheduled_task_id is None or job.meta.get(cron._SKIPPED):
         return
-
-    if not task._schedule(exclude_job_name=job.name) and task.job_name == job.name:
-        task.job_name = None
-    task.save(schedule_job=False, clean=False, update_fields=_SCHEDULING_FIELDS)
+    using = job.meta.get("scheduler_task_database", "default")
+    with transaction.atomic(using=using):
+        task = Task.objects.using(using).select_for_update().filter(pk=job.scheduled_task_id).first()
+        if task is None or not cron.same_generation(task, job):
+            return
+        now = timezone.now()
+        if failed:
+            counters: dict[str, Any] = {"failed_runs": F("failed_runs") + 1, "last_failed_run": now}
+        else:
+            counters = {"successful_runs": F("successful_runs") + 1, "last_successful_run": now}
+        # Count in the database rather than through this instance. The row lock serializes completions
+        # where the database has one; on SQLite it does not, and another run of the same task finishing
+        # at the same time would otherwise drop this result.
+        Task.objects.using(using).filter(pk=task.pk).update(updated_at=now, **counters)
+        if task.job_name != job.name:
+            # Not the task's pending execution - a manual "Enqueue now" run, or a leftover duplicate. The
+            # scheduled job is still waiting, so scheduling a successor here would start a second chain.
+            logger.debug(f"Job {job.name} is not the scheduled run of task {task.name}, not scheduling a successor")
+        elif task.task_type == TaskType.CRON:
+            task.job_name = None
+            cron.reconcile(task, exclude=job.name)
+        elif job.task_type != str(TaskType.CRON):
+            # The finishing job is still in the active registry, so discount it rather than clearing the
+            # pointer: a failed reschedule must not leave the task looking unscheduled to a racing sweep.
+            if not task._schedule(exclude_job_name=job.name) and task.schedule_updated and task.job_name == job.name:
+                task.job_name = None
+            models.Model.save(task, using=using, update_fields=(*_SCHEDULING_FIELDS, "updated_at"))
+    if failed:
+        try:
+            mail_admins(f"Task {task.pk}/{task.name} has failed", "See django-admin for logs")
+        except Exception:
+            # Reporting failure must not retry already committed completion bookkeeping.
+            logger.exception("Could not report failed task %s", task.name)
 
 
 def failure_callback(job: JobModel, connection: ConnectionType, result: Any, *args: Any, **kwargs: Any) -> None:
-    task = _get_task_for_job(job)
-    if task is None:
-        logger.warning(f"Could not find task for job {job.name}")
-        return
-    mail_admins(
-        f"Task {task.id}/{task.name} has failed",
-        "See django-admin for logs",
-    )
-    _complete_run(task, job, failed=True)
+    _complete_task(job, failed=True)
 
 
 def success_callback(job: JobModel, connection: ConnectionType, result: Any, *args: Any, **kwargs: Any) -> None:
-    task = _get_task_for_job(job)
-    if task is None:
-        logger.warning(f"Could not find task for job {job.name}")
-        return
-    _complete_run(task, job, failed=False)
+    _complete_task(job, failed=False)
 
 
 def get_queue_choices() -> list[tuple[str, str]]:
@@ -106,6 +100,11 @@ class TaskType(models.TextChoices):
 
 
 class Task(models.Model):
+    #: False when the last save reached the database but could not reach the broker to update
+    #: the schedule. The row is correct, the schedule is stale until the next scheduler sweep
+    #: repairs it. Not a database field - it only describes the save that just ran.
+    schedule_updated: bool = True
+
     class TimeUnits(models.TextChoices):
         SECONDS = "seconds", _("seconds")
         MINUTES = "minutes", _("minutes")
@@ -216,24 +215,28 @@ class Task(models.Model):
         return utils.callable_func(self.callable)
 
     @admin.display(boolean=True, description=_("is scheduled?"))  # type: ignore[misc]
-    def is_scheduled(self) -> bool:
-        """Check whether a next job for this task is queued/scheduled to be executed"""
-        if self.job_name is None:  # no job_id => is not scheduled
-            return False
-        # check whether job_id is in scheduled/queued/active jobs
-        with self.rqueue.connection.pipeline() as pipeline:
-            self.rqueue.scheduled_job_registry.exists(pipeline, self.job_name)
-            self.rqueue.queued_job_registry.exists(pipeline, self.job_name)
-            self.rqueue.active_job_registry.exists(pipeline, self.job_name)
-            results = pipeline.execute()
-            res = any(item is not None for item in results)
+    def is_scheduled(self) -> bool | None:
+        """Check whether the job this task owns is queued/scheduled to be executed.
 
-        # If the job_name is not scheduled/queued/started,
-        # update the job_id to None. (The job_id belongs to a previous run which is completed)
-        if not res:
-            self.job_name = None
-            super().save(update_fields=["job_name", "updated_at"])
-        return res
+        This is a membership check on ``job_name`` for every task type: one pipelined read,
+        cheap enough to run once per row in the admin changelist. Reconciliation needs the
+        full registry sweep in ``cron.read_schedule`` instead, which is far more expensive.
+
+        Returns None when the broker cannot be read, which the admin shows as an unknown
+        state rather than a checkmark. Callers deciding whether to enqueue must treat None
+        as "possibly already scheduled", never as False.
+        """
+        if self.job_name is None:
+            return False
+        try:
+            with self.rqueue.connection.pipeline() as pipeline:
+                self.rqueue.scheduled_job_registry.exists(pipeline, self.job_name)
+                self.rqueue.queued_job_registry.exists(pipeline, self.job_name)
+                self.rqueue.active_job_registry.exists(pipeline, self.job_name)
+                return any(item is not None for item in pipeline.execute())
+        except BrokerErrorTypes:
+            logger.exception("Could not inspect task %s", self.name)
+            return None
 
     @admin.display(description="Callable")  # type: ignore[misc]
     def function_string(self) -> str:
@@ -255,6 +258,8 @@ class Task(models.Model):
 
     def _next_job_id(self) -> str:
         addition = timezone.now().strftime("%Y%m%d%H%M%S%f")
+        if self._state.db and self._state.db != "default":
+            addition = f"{self._state.db}:{addition}"
         return f"{self.queue}:{self.id}:{addition}"
 
     def _enqueue_args(self) -> dict[str, Any]:
@@ -266,7 +271,7 @@ class Task(models.Model):
         - set job meta
         """
         res = {
-            "meta": {},
+            "meta": {"scheduler_task_database": self._state.db or "default"},
             "task_type": self.task_type,
             "scheduled_task_id": self.id,
             "on_success": Callback(success_callback),
@@ -291,19 +296,38 @@ class Task(models.Model):
 
     def enqueue_to_run(self) -> bool:
         """Enqueue task to run now as a different instance from the scheduled task."""
-        kwargs = self._enqueue_args()
-        self.rqueue.create_and_enqueue_job(run_task, args=(self.task_type, self.id), when=None, **kwargs)
+        using = self._state.db or router.db_for_write(Task, instance=self)
+        with transaction.atomic(using=using):
+            current = Task.objects.using(using).select_for_update().get(pk=self.pk)
+            kwargs = current._enqueue_args()
+            if current.task_type == TaskType.CRON:
+                kwargs["meta"][cron._MANUAL] = "1"
+            current.rqueue.create_and_enqueue_job(run_task, args=(current.task_type, current.pk), when=None, **kwargs)
         return True
 
-    def unschedule(self) -> bool:
-        """Remove a job from django-queue.
+    def unschedule(self, *, using: str | None = None, enabled: bool | None = None) -> bool:
+        """Remove waiting executions without deleting a running job or manual cron run.
 
-        If a job is queued to be executed or scheduled to be executed, it will remove it.
+        Only the schedule is written. Pass ``enabled`` to change that flag on the locked row
+        as well; leaving it unset keeps the stored value, so a caller holding a stale
+        instance cannot rewrite the flag as a side effect of dequeuing.
         """
-        if self.job_name is not None:
-            self.rqueue.delete_job(self.job_name)
-            self.job_name = None
-        self.save(schedule_job=False, clean=False)
+        using = using or self._state.db or router.db_for_write(Task, instance=self)
+        with transaction.atomic(using=using):
+            current = Task.objects.using(using).select_for_update().get(pk=self.pk)
+            if current.task_type == TaskType.CRON:
+                cron.retire_schedule(current)
+            elif current.job_name is not None:
+                current.rqueue.delete_job(current.job_name)
+            current.job_name = None
+            update_fields = ["job_name", "updated_at"]
+            if enabled is not None:
+                current.enabled = enabled
+                update_fields.append("enabled")
+            models.Model.save(current, using=using, update_fields=update_fields)
+            cron._copy_runtime(current, self)
+            if enabled is not None:
+                self.enabled = enabled
         return True
 
     def _schedule_time(self) -> datetime:
@@ -363,7 +387,16 @@ class Task(models.Model):
             this the task would look like it is already scheduled and never get a successor.
         :returns: True if a job was scheduled, False otherwise.
         """
-        if self.job_name != exclude_job_name and self.is_scheduled():
+        self.schedule_updated = True
+        if self.job_name == exclude_job_name:
+            scheduled = False
+        else:
+            scheduled = self.is_scheduled()
+        if scheduled is None:
+            self.schedule_updated = False
+            logger.warning(f"Could not read the schedule for task {self.name}; not enqueuing another job")
+            return False
+        if scheduled:
             logger.debug(f"Task {self.name} already scheduled")
             return False
         if not self.enabled:
@@ -374,49 +407,96 @@ class Task(models.Model):
             logger.debug(f"Task {self!s} scheduled time is in the past, not scheduling")
             return False
         kwargs = self._enqueue_args()
-        job = self.rqueue.create_and_enqueue_job(run_task, args=(self.task_type, self.id), when=schedule_time, **kwargs)
+        try:
+            job = self.rqueue.create_and_enqueue_job(
+                run_task, args=(self.task_type, self.id), when=schedule_time, **kwargs
+            )
+        except BrokerErrorTypes:
+            # A successor's broker failure must not roll back the completed run's counters.
+            self.schedule_updated = False
+            logger.exception("Could not schedule task %s; leaving its job reference unchanged", self.name)
+            return False
         self.job_name = job.name
         return True
 
-    def _refresh_run_state(self) -> None:
-        """Re-read the fields the run machinery owns, so saving a stale instance cannot undo a finished run."""
-        if self.pk is None:
+    def _refresh_run_state(self, current: Optional["Task"]) -> None:
+        """Take the fields the run machinery owns from the locked row, so saving a stale instance
+        cannot undo a run that finished while the caller held it.
+
+        Cron tasks get the wider ``cron._copy_runtime`` instead, which also carries the schedule.
+        """
+        if current is None:  # a new row, or one deleted underneath us
             return
-        current = Task.objects.filter(pk=self.pk).values(*_RUN_STATE_FIELDS).first()
-        if current is None:  # deleted underneath us
-            return
-        for field_name, value in current.items():
-            setattr(self, field_name, value)
+        for field_name in _RUN_STATE_FIELDS:
+            setattr(self, field_name, getattr(current, field_name))
 
     def save(self, **kwargs: Any) -> None:
+        using = kwargs.get("using") or router.db_for_write(Task, instance=self)
+        with transaction.atomic(using=using):
+            current = Task.objects.using(using).select_for_update().filter(pk=self.pk).first() if self.pk else None
+            self._save_locked(current, **kwargs)
+
+    def _save_locked(self, current: Optional["Task"], **kwargs: Any) -> None:
         should_clean = kwargs.pop("clean", True)
         schedule_job = kwargs.pop("schedule_job", True)
+        if kwargs.get("update_fields") is not None:
+            fields = set(kwargs["update_fields"])
+            if not fields:
+                return
+            kwargs["update_fields"] = fields | {"updated_at"}
+            if current is not None:
+                for field in self._meta.concrete_fields:
+                    if field.name not in fields and field.attname not in fields:
+                        setattr(self, field.attname, getattr(current, field.attname))
+        involves_cron = self.task_type == TaskType.CRON or (current is not None and current.task_type == TaskType.CRON)
+        identity_changed = current is not None and (current.queue, current.task_type) != (self.queue, self.task_type)
+        if involves_cron:
+            if current is not None:
+                requested_time = self.scheduled_time
+                cron._copy_runtime(current, self)
+                if identity_changed:
+                    self.scheduled_time = requested_time
+            elif not self._state.adding:
+                raise Task.DoesNotExist("Cannot save a task that was deleted")
         if should_clean:
             self.clean()
-        if schedule_job:
-            self._refresh_run_state()
-        if update_fields := kwargs.get("update_fields"):
-            kwargs["update_fields"] = set(update_fields).union({"updated_at"})
+        if schedule_job and not involves_cron:
+            self._refresh_run_state(current)
+        if involves_cron and identity_changed and current is not None:
+            cron.retire_schedule(current)
+            self.job_name = None
+            if kwargs.get("update_fields"):
+                kwargs["update_fields"] |= {"job_name"}
         super().save(**kwargs)
         if schedule_job:
-            self._schedule()
-            super().save(update_fields=(*_SCHEDULING_FIELDS, "updated_at"))
+            if self.task_type == TaskType.CRON:
+                self.schedule_updated = cron.reconcile(self)
+            else:
+                self._schedule()
+                super().save(using=self._state.db, update_fields=(*_SCHEDULING_FIELDS, "updated_at"))
 
     def reschedule_if_needed(self) -> bool:
         """Give the task a pending job if it has none, writing back only the scheduling fields.
 
-        Used by the scheduler loop, which works from instances read before the loop started: a full-row save there
-        would restore an old job name a completion callback has since replaced, adding a second recurring chain.
+        Used by the scheduler loop, which works from instances read before the loop started: a full-row
+        save there would restore an old job name a completion callback has since replaced, adding a
+        second recurring chain. Cron tasks reconcile instead, which also clears any duplicate.
 
-        :returns: True if a job was scheduled, False otherwise.
+        :returns: True if the call gave the task a job it did not have.
         """
+        if self.task_type == TaskType.CRON:
+            previous = self.job_name
+            self.schedule_updated = cron.reconcile(self)
+            return self.job_name is not None and self.job_name != previous
         scheduled = self._schedule()
         self.save(schedule_job=False, clean=False, update_fields=_SCHEDULING_FIELDS)
         return scheduled
 
     def delete(self, **kwargs: Any) -> None:
-        self.unschedule()
-        super().delete(**kwargs)
+        using = kwargs.get("using") or router.db_for_write(Task, instance=self)
+        with transaction.atomic(using=using):
+            self.unschedule(using=using)
+            super().delete(**kwargs)
 
     def interval_seconds(self) -> float:
         kwargs = {
@@ -507,7 +587,9 @@ def get_scheduled_task(task_type_str: str, task_id: int) -> Task:
         task_type = TaskType(task_type_str)
     except ValueError:
         raise ValueError(f"Invalid task type {task_type_str}")
-    task = Task.objects.filter(task_type=task_type, id=task_id).first()
+    job = get_current_job()
+    using = job.meta.get("scheduler_task_database", "default") if job else "default"
+    task = Task.objects.using(using).filter(task_type=task_type, id=task_id).first()
     if task is None:
         raise ValueError(f"Job {task_type}:{task_id} does not exist")
     return task  # type: ignore[no-any-return]
@@ -517,6 +599,20 @@ def run_task(task_model: str, task_id: int) -> Any:
     """Run a scheduled job"""
     if isinstance(task_id, str):
         task_id = int(task_id)
+    job = get_current_job()
+    if job is not None and job.task_type == str(TaskType.CRON):
+        using = job.meta.get("scheduler_task_database", "default")
+        with transaction.atomic(using=using):
+            task = Task.objects.using(using).select_for_update().filter(pk=job.scheduled_task_id).first()
+            allowed = False
+            if task is not None and cron.same_generation(task, job):
+                if job.meta.get(cron._MANUAL):
+                    allowed = task.task_type == job.task_type
+                elif task.task_type == TaskType.CRON and task.queue == job.queue_name:
+                    allowed = cron.reconcile(task, create=False) and task.enabled and task.job_name == job.name
+            if not allowed:
+                job.meta[cron._SKIPPED] = "1"
+                return {"skipped": "obsolete recurring job"}
     scheduled_task = get_scheduled_task(task_model, task_id)
     logger.debug(f"Running task {scheduled_task!s}")
     args = scheduled_task.parse_args()

--- a/scheduler/redis_models/job.py
+++ b/scheduler/redis_models/job.py
@@ -17,6 +17,8 @@ from scheduler.types import ConnectionType, FunctionReferenceType, Self
 from ..helpers.utils import current_timestamp
 from .registry.base_registry import JobNamesRegistry
 
+MISSING_REGISTRY_KEY_PREFIX = ":scheduler:missing:"
+
 
 class TimeoutFormatError(Exception):
     pass

--- a/scheduler/tests/conf.py
+++ b/scheduler/tests/conf.py
@@ -96,6 +96,8 @@ settings.SCHEDULER_QUEUES = {
 # into several seconds of backoff and makes any view that probes every queue (e.g. _find_job) extremely slow.
 # Disable connection retries on the test queues so unreachable brokers fail fast.
 for _queue_settings in settings.SCHEDULER_QUEUES.values():
+    if _queue_settings.get("PORT") == 6379:
+        _queue_settings["PORT"] = int(os.getenv("BROKER_PORT", "6379"))
     _queue_settings.setdefault("CONNECTION_KWARGS", {}).setdefault("retry", None)
 
 conf_settings()

--- a/scheduler/tests/test_task_types/test_completion_errors.py
+++ b/scheduler/tests/test_task_types/test_completion_errors.py
@@ -1,0 +1,119 @@
+"""Completion bookkeeping survives notification and successor-scheduling failures."""
+
+from datetime import timedelta
+from smtplib import SMTPException
+from unittest.mock import patch
+
+from django.db import connection
+from django.test import TransactionTestCase
+from django.utils import timezone
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from scheduler.helpers.queues import Queue, get_queue
+from scheduler.models import Task, TaskType
+from scheduler.models.task import failure_callback
+from scheduler.redis_models import JobModel, JobStatus
+from scheduler.tests import conf  # noqa: F401
+from scheduler.tests.testtools import SchedulerBaseCase, task_factory
+
+
+class TestCompletionMail(TransactionTestCase):
+    def setUp(self):
+        self.queue = get_queue()
+        self.queue.connection.flushall()
+
+    def test_failure_mail_runs_after_the_completion_transaction(self):
+        for task_type in TaskType:
+            with self.subTest(task_type=task_type):
+                task = task_factory(task_type)
+                job = JobModel.get(task.job_name, connection=self.queue.connection)
+                observed = []
+
+                def send_mail(*args, task=task, observed=observed):
+                    observed.append((connection.in_atomic_block, Task.objects.get(pk=task.pk).failed_runs))
+
+                with patch("scheduler.models.task.mail_admins", side_effect=send_mail):
+                    failure_callback(job, self.queue.connection, None)
+
+                self.assertEqual(observed, [(False, 1)])
+
+    def test_mail_failure_does_not_interrupt_completion(self):
+        for task_type in TaskType:
+            with self.subTest(task_type=task_type):
+                task = task_factory(task_type)
+                job = JobModel.get(task.job_name, connection=self.queue.connection)
+
+                with patch("scheduler.models.task.mail_admins", side_effect=SMTPException("mail offline")):
+                    failure_callback(job, self.queue.connection, None)
+
+                task.refresh_from_db()
+                self.assertEqual(task.failed_runs, 1)
+                self.assertIsNotNone(task.last_failed_run)
+
+
+class TestCompletionBrokerErrors(SchedulerBaseCase):
+    def test_successor_enqueue_failure_preserves_the_completed_run(self):
+        for task_type in (TaskType.REPEATABLE, TaskType.CRON):
+            for failed in (False, True):
+                with self.subTest(task_type=task_type, failed=failed):
+                    callable_name = "scheduler.tests.jobs.failing_job" if failed else "scheduler.tests.jobs.test_job"
+                    task = task_factory(task_type, callable_name=callable_name)
+                    queue = task.rqueue
+                    job = JobModel.get(task.job_name, connection=queue.connection)
+                    queue.scheduled_job_registry.delete(queue.connection, job.name)
+
+                    with patch.object(Queue, "create_and_enqueue_job", side_effect=RedisConnectionError("offline")):
+                        queue.run_sync(job)
+
+                    task.refresh_from_db()
+                    self.assertEqual(task.successful_runs, 0 if failed else 1)
+                    self.assertEqual(task.failed_runs, 1 if failed else 0)
+                    self.assertIsNotNone(task.last_failed_run if failed else task.last_successful_run)
+                    self.assertEqual(job.status, JobStatus.FAILED if failed else JobStatus.FINISHED)
+                    task.save(clean=False)
+                    self.assertNotEqual(task.job_name, job.name)
+                    names = queue.scheduled_job_registry.all(queue.connection)
+                    self.assertEqual(
+                        [name for name in names if name.startswith(f"{task.queue}:{task.pk}:")], [task.job_name]
+                    )
+
+    def test_unreadable_schedule_is_reported_until_a_successful_save(self):
+        for task_type in (TaskType.ONCE, TaskType.REPEATABLE):
+            with self.subTest(task_type=task_type):
+                task = task_factory(task_type)
+                owner = task.job_name
+                with patch.object(
+                    type(task.rqueue.connection), "pipeline", side_effect=RedisConnectionError("offline")
+                ):
+                    task.save(clean=False)
+
+                self.assertFalse(task.schedule_updated)
+                self.assertEqual(Task.objects.get(pk=task.pk).job_name, owner)
+                task.save(clean=False)
+                self.assertTrue(task.schedule_updated)
+                self.assertEqual(task.job_name, owner)
+
+    def test_normal_scheduling_noops_do_not_report_a_broker_error(self):
+        for task_type in (TaskType.ONCE, TaskType.REPEATABLE):
+            with self.subTest(task_type=task_type):
+                task = task_factory(task_type, enabled=False)
+                self.assertTrue(task.schedule_updated)
+                task.enabled = True
+                task.scheduled_time = timezone.now() - timedelta(hours=1)
+                task.repeat = 0
+                task.save(clean=False)
+                self.assertIsNone(task.job_name)
+                self.assertTrue(task.schedule_updated)
+
+    def test_enqueue_failure_reports_a_saved_but_unscheduled_task(self):
+        for task_type in (TaskType.ONCE, TaskType.REPEATABLE):
+            with self.subTest(task_type=task_type):
+                task = task_factory(task_type, instance_only=True)
+                with patch.object(Queue, "create_and_enqueue_job", side_effect=RedisConnectionError("offline")):
+                    task.save()
+
+                self.assertFalse(task.schedule_updated)
+                self.assertIsNone(Task.objects.get(pk=task.pk).job_name)
+                task.save()
+                self.assertTrue(task.schedule_updated)
+                self.assertTrue(task.is_scheduled())

--- a/scheduler/tests/test_task_types/test_cron_concurrency.py
+++ b/scheduler/tests/test_task_types/test_cron_concurrency.py
@@ -1,0 +1,106 @@
+"""Exercise competing transactions on databases with real row-level locks."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
+from unittest import mock
+
+from django.contrib import admin
+from django.db import close_old_connections, connection
+from django.test import RequestFactory, TransactionTestCase, skipUnlessDBFeature
+
+from scheduler.admin.task_admin import TaskAdmin
+from scheduler.helpers.queues import get_queue
+from scheduler.models import Task, TaskType
+from scheduler.models.task import success_callback
+from scheduler.redis_models import JobModel
+from scheduler.tests import conf  # noqa: F401
+from scheduler.tests.testtools import task_factory
+
+
+@skipUnlessDBFeature("has_select_for_update")
+class TestCronConcurrency(TransactionTestCase):
+    def setUp(self):
+        self.queue = get_queue("default")
+        self.queue.connection.flushall()
+        self.task = task_factory(TaskType.CRON)
+
+    def race(self, actions):
+        barrier = Barrier(len(actions))
+
+        def run(action):
+            close_old_connections()
+            try:
+                barrier.wait(timeout=10)
+                action()
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=len(actions)) as pool:
+            futures = [pool.submit(run, action) for action in actions]
+            for future in futures:
+                future.result(timeout=20)
+
+    def test_concurrent_manual_completions_keep_every_count_and_the_owner(self):
+        owner = self.task.job_name
+        for _ in range(8):
+            self.task.enqueue_to_run()
+        jobs = [
+            JobModel.get(name, connection=self.queue.connection)
+            for name in self.queue.queued_job_registry.all(self.queue.connection)
+        ]
+        self.race([lambda job=job: success_callback(job, self.queue.connection, None) for job in jobs])
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.successful_runs, 8)
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.queue.scheduled_job_registry.all(self.queue.connection), [owner])
+
+    def test_stale_scheduler_saves_racing_completion_keep_one_successor(self):
+        job = JobModel.get(self.task.job_name, connection=self.queue.connection)
+        self.queue.scheduled_job_registry.delete(self.queue.connection, job.name)
+        job.prepare_for_execution("racing-worker", self.queue.active_job_registry, self.queue.connection)
+        stale_tasks = [Task.objects.get(pk=self.task.pk) for _ in range(4)]
+        self.race(
+            [lambda: success_callback(job, self.queue.connection, None)]
+            + [lambda task=task: task.save(clean=False) for task in stale_tasks]
+        )
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.successful_runs, 1)
+        self.assertNotEqual(self.task.job_name, job.name)
+        self.assertEqual(self.queue.scheduled_job_registry.all(self.queue.connection), [self.task.job_name])
+
+    def test_concurrent_repair_adopts_only_one_replacement(self):
+        self.queue.delete_job(self.task.job_name)
+        stale_tasks = [Task.objects.get(pk=self.task.pk) for _ in range(4)]
+        self.race([lambda task=task: task.save(clean=False) for task in stale_tasks])
+        self.task.refresh_from_db()
+        self.assertEqual(self.queue.scheduled_job_registry.all(self.queue.connection), [self.task.job_name])
+
+    def test_scheduler_cannot_reschedule_during_admin_bulk_delete(self):
+        from scheduler.worker.scheduler import _reschedule_tasks
+
+        unscheduled = Event()
+        rescheduled = Event()
+        original_unschedule = Task.unschedule
+
+        def pause_after_unschedule(task, *args, **kwargs):
+            result = original_unschedule(task, *args, **kwargs)
+            unscheduled.set()
+            if not connection.in_atomic_block:
+                self.assertTrue(rescheduled.wait(timeout=10), "scheduler did not finish its competing sweep")
+            return result
+
+        def sweep_after_unschedule():
+            self.assertTrue(unscheduled.wait(timeout=10), "admin did not unschedule the task")
+            try:
+                _reschedule_tasks()
+            finally:
+                rescheduled.set()
+
+        task_admin = TaskAdmin(Task, admin.site)
+        request = RequestFactory().post("/admin/scheduler/task/")
+        queryset = Task.objects.filter(pk=self.task.pk)
+        with mock.patch.object(Task, "unschedule", pause_after_unschedule):
+            self.race([lambda: task_admin.delete_queryset(request, queryset), sweep_after_unschedule])
+
+        self.assertFalse(Task.objects.filter(pk=self.task.pk).exists())
+        self.assertEqual(self.queue.scheduled_job_registry.all(self.queue.connection), [])

--- a/scheduler/tests/test_task_types/test_cron_ownership.py
+++ b/scheduler/tests/test_task_types/test_cron_ownership.py
@@ -1,0 +1,603 @@
+"""Cron ownership regressions using real Task rows and broker registries."""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.contrib import admin
+from django.core import mail
+from django.test import RequestFactory
+from django.utils import timezone
+
+from scheduler.admin.task_admin import TaskAdmin
+from scheduler.models import Task, TaskType
+from scheduler.models.task import failure_callback, run_task, success_callback
+from scheduler.redis_models import JobModel
+from scheduler.tests import conf  # noqa: F401
+from scheduler.tests.testtools import SchedulerBaseCase, task_factory
+from scheduler.worker.scheduler import _reschedule_tasks
+
+
+class TestCronOwnership(SchedulerBaseCase):
+    def setUp(self):
+        super().setUp()
+        self.task = task_factory(TaskType.CRON, cron_string="* * * * *")
+        self.queue = self.task.rqueue
+
+    def job(self, name):
+        job = JobModel.get(name, connection=self.queue.connection)
+        self.assertIsNotNone(job)
+        return job
+
+    def scheduled(self):
+        return self.queue.scheduled_job_registry.all(self.queue.connection)
+
+    def execute(self, job):
+        self.queue.scheduled_job_registry.delete(self.queue.connection, job.name)
+        self.queue.queued_job_registry.delete(self.queue.connection, job.name)
+        self.queue.run_sync(job)
+
+    def duplicate(self):
+        return self.queue.create_and_enqueue_job(
+            run_task,
+            args=(self.task.task_type, self.task.pk),
+            when=self.task.scheduled_time,
+            **self.task._enqueue_args(),
+        )
+
+    def manual_job(self):
+        before = set(self.queue.queued_job_registry.all(self.queue.connection))
+        self.task.enqueue_to_run()
+        names = set(self.queue.queued_job_registry.all(self.queue.connection)) - before
+        self.assertEqual(len(names), 1)
+        return self.job(names.pop())
+
+    def test_manual_outcomes_preserve_the_recurring_owner(self):
+        original = self.task.job_name
+        for failed in (False, True):
+            with self.subTest(failed=failed):
+                job = self.manual_job()
+                if failed:
+                    with patch.object(Task, "callable_func", side_effect=ValueError("manual failure")):
+                        self.execute(job)
+                else:
+                    self.execute(job)
+                self.task.refresh_from_db()
+                self.assertEqual(self.scheduled(), [original])
+                self.assertEqual(self.task.job_name, original)
+        self.assertEqual(self.task.successful_runs, 1)
+        self.assertEqual(self.task.failed_runs, 1)
+
+    def test_owner_completion_advances_once_with_callback_still_active(self):
+        for failed in (False, True):
+            with self.subTest(failed=failed):
+                original = self.task.job_name
+                job = self.job(original)
+                if failed:
+                    with patch.object(Task, "callable_func", side_effect=ValueError("scheduled failure")):
+                        self.execute(job)
+                else:
+                    self.execute(job)
+                self.task.refresh_from_db()
+                self.assertNotEqual(self.task.job_name, original)
+                self.assertEqual(self.scheduled(), [self.task.job_name])
+        self.assertEqual(self.task.successful_runs, 1)
+        self.assertEqual(self.task.failed_runs, 1)
+
+    def test_stale_save_preserves_successor_and_run_count(self):
+        self.execute(self.job(self.task.job_name))
+        owner = Task.objects.get(pk=self.task.pk).job_name
+        self.task.save(clean=False)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.task.successful_runs, 1)
+        self.assertEqual(self.scheduled(), [owner])
+
+    def test_missing_database_pointer_adopts_existing_job(self):
+        original = self.task.job_name
+        Task.objects.filter(pk=self.task.pk).update(job_name=None)
+        _reschedule_tasks()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.job_name, original)
+        self.assertEqual(self.scheduled(), [original])
+
+    def test_missing_job_record_is_replaced(self):
+        original = self.task.job_name
+        self.job(original).delete(self.queue.connection)
+        self.task.save(clean=False)
+        self.assertNotEqual(self.task.job_name, original)
+        self.assertEqual(self.scheduled(), [self.task.job_name])
+
+    def test_dequeue_handoff_does_not_create_a_second_chain(self):
+        job = self.job(self.task.job_name)
+        self.queue.enqueue_job(job)
+        self.queue.queued_job_registry.delete(self.queue.connection, job.name)
+        self.task.save(clean=False)
+        self.assertEqual(self.task.job_name, job.name)
+        self.assertEqual(self.scheduled(), [])
+
+    def test_lost_dequeue_handoff_eventually_recovers(self):
+        job = self.job(self.task.job_name)
+        self.queue.enqueue_job(job)
+        self.queue.queued_job_registry.delete(self.queue.connection, job.name)
+        self.task.save(clean=False)
+        with patch("django.utils.timezone.now", return_value=timezone.now() + timedelta(seconds=job.timeout + 61)):
+            self.task.save(clean=False)
+        self.assertNotEqual(self.task.job_name, job.name)
+        self.assertEqual(self.scheduled(), [self.task.job_name])
+
+    def test_admin_display_cannot_overwrite_new_state(self):
+        self.execute(self.job(self.task.job_name))
+        owner = Task.objects.get(pk=self.task.pk).job_name
+        self.task.is_scheduled()
+        current = Task.objects.get(pk=self.task.pk)
+        self.assertEqual(current.job_name, owner)
+        self.assertEqual(current.successful_runs, 1)
+
+    def test_reconcile_removes_waiting_duplicates_but_preserves_manual_job(self):
+        original = self.task.job_name
+        self.duplicate()
+        self.queue.enqueue_job(self.duplicate())
+        manual = self.manual_job()
+        _reschedule_tasks()
+        self.assertEqual(self.scheduled(), [original])
+        self.assertEqual(self.queue.queued_job_registry.all(self.queue.connection), [manual.name])
+
+    def test_dequeued_duplicate_does_not_execute_callable_or_count_success(self):
+        duplicate = self.duplicate()
+        effects = []
+        with patch.object(Task, "callable_func", return_value=lambda: effects.append("executed")):
+            self.execute(duplicate)
+        self.task.refresh_from_db()
+        self.assertEqual(effects, [])
+        self.assertEqual(self.task.successful_runs, 0)
+        self.assertEqual(self.scheduled(), [self.task.job_name])
+
+    def test_disabling_stale_task_removes_copies_and_preserves_new_configuration(self):
+        self.duplicate()
+        Task.objects.filter(pk=self.task.pk).update(cron_string="*/5 * * * *")
+        self.task.unschedule(enabled=False)
+        self.task.refresh_from_db()
+        self.assertFalse(self.task.enabled)
+        self.assertEqual(self.task.cron_string, "*/5 * * * *")
+        self.assertIsNone(self.task.job_name)
+        self.assertEqual(self.scheduled(), [])
+
+    def test_unschedule_keeps_the_stored_enabled_flag(self):
+        """Dequeuing must not let a stale instance rewrite ``enabled`` as a side effect."""
+        self.task.enabled = False
+        self.task.unschedule()
+        self.task.refresh_from_db()
+        self.assertTrue(self.task.enabled)
+        self.assertIsNone(self.task.job_name)
+        self.assertEqual(self.scheduled(), [])
+
+    def test_admin_display_does_not_scan_the_registries(self):
+        """The changelist column runs per row, so it checks ``job_name`` rather than reading
+        every registry the way reconciliation does."""
+        from scheduler.models import cron
+
+        with patch.object(cron, "read_schedule", side_effect=AssertionError("registry sweep")):
+            self.assertTrue(self.task.is_scheduled())
+            self.queue.delete_job(self.task.job_name)
+            self.assertFalse(self.task.is_scheduled())
+
+    def test_unreadable_broker_reports_an_unknown_schedule(self):
+        """A broker outage must not show as a scheduled checkmark in the admin."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        with patch.object(type(self.queue.connection), "pipeline", side_effect=RedisConnectionError("offline")):
+            self.assertIsNone(self.task.is_scheduled())
+
+    def test_deleted_task_cannot_be_resurrected_by_stale_save(self):
+        Task.objects.get(pk=self.task.pk).delete()
+        with self.assertRaises(Task.DoesNotExist):
+            self.task.save(clean=False)
+        self.assertFalse(Task.objects.filter(pk=self.task.pk).exists())
+
+    def test_jobs_from_old_database_generation_do_not_execute(self):
+        jobs = [self.job(self.task.job_name), self.manual_job()]
+        Task.objects.filter(pk=self.task.pk).update(created_at=timezone.now() + timedelta(seconds=1))
+        effects = []
+        with patch.object(Task, "callable_func", return_value=lambda: effects.append("executed")):
+            for job in jobs:
+                self.execute(job)
+        self.task.refresh_from_db()
+        self.assertEqual(effects, [])
+        self.assertEqual(self.task.successful_runs, 0)
+        self.assertEqual(self.task.failed_runs, 0)
+
+    def test_manual_job_survives_queue_change_without_advancing_new_owner(self):
+        job = self.manual_job()
+        self.task.queue = "test3"
+        self.task.save(clean=False)
+        owner, when = self.task.job_name, self.task.scheduled_time
+        effects = []
+        with patch.object(Task, "callable_func", return_value=lambda: effects.append("executed")):
+            self.execute(job)
+        self.task.refresh_from_db()
+        self.assertEqual(effects, ["executed"])
+        self.assertEqual(self.task.successful_runs, 1)
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.task.scheduled_time, when)
+        self.assertEqual(self.scheduled(), [])
+
+    def test_queue_change_retires_old_recurring_payload(self):
+        job = self.job(self.task.job_name)
+        self.task.queue = "test3"
+        self.task.save(clean=False)
+        owner = self.task.job_name
+        effects = []
+        with patch.object(Task, "callable_func", return_value=lambda: effects.append("executed")):
+            self.execute(job)
+        self.task.refresh_from_db()
+        self.assertNotEqual(owner, job.name)
+        self.assertEqual(effects, [])
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.scheduled(), [])
+
+    def test_partial_save_ignores_unsaved_type_change(self):
+        owner = self.task.job_name
+        self.task.task_type = TaskType.ONCE
+        self.task.name = "renamed"
+        self.task.save(update_fields=["name"], clean=False)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.task_type, TaskType.CRON)
+        self.assertEqual(self.task.name, "renamed")
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.scheduled(), [owner])
+
+    def test_partial_stale_save_preserves_current_once_job(self):
+        current = Task.objects.get(pk=self.task.pk)
+        current.task_type = TaskType.ONCE
+        current.save(clean=False)
+        self.task.name = "renamed-once"
+        self.task.save(update_fields=["name"], clean=False)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.task_type, TaskType.ONCE)
+        self.assertEqual(self.task.job_name, current.job_name)
+        self.assertEqual(self.scheduled(), [current.job_name])
+
+    def test_completion_after_disable_does_not_reenable(self):
+        job = self.job(self.task.job_name)
+        self.task.unschedule(enabled=False)
+        success_callback(job, self.queue.connection, None)
+        self.task.refresh_from_db()
+        self.assertFalse(self.task.enabled)
+        self.assertIsNone(self.task.job_name)
+        self.assertEqual(self.scheduled(), [])
+
+    def test_running_cron_keeps_outcome_after_conversion_to_once(self):
+        job = self.job(self.task.job_name)
+        self.queue.scheduled_job_registry.delete(self.queue.connection, job.name)
+        job.prepare_for_execution("transition", self.queue.active_job_registry, self.queue.connection)
+        self.task.task_type = TaskType.ONCE
+        self.task.save(clean=False)
+        owner, when = self.task.job_name, self.task.scheduled_time
+        with self.settings(ADMINS=[("Admin", "admin@example.com")]):
+            failure_callback(job, self.queue.connection, None)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.failed_runs, 1)
+        self.assertIsNotNone(self.task.last_failed_run)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.task.scheduled_time, when)
+
+    def test_old_duplicate_and_owner_cannot_multiply_successors(self):
+        for owner_first in (False, True):
+            with self.subTest(owner_first=owner_first):
+                owner, duplicate = self.job(self.task.job_name), self.duplicate()
+                for job in [owner, duplicate] if owner_first else [duplicate, owner]:
+                    self.execute(job)
+                self.task.refresh_from_db()
+                self.assertEqual(self.scheduled(), [self.task.job_name])
+        self.assertEqual(self.task.successful_runs, 2)
+
+    def test_broker_read_failure_neither_runs_nor_creates_another_job(self):
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        owner = self.job(self.task.job_name)
+        effects = []
+        with (
+            patch.object(type(self.queue.connection), "zscan_iter", side_effect=RedisConnectionError("offline")),
+            patch.object(Task, "callable_func", return_value=lambda: effects.append("executed")),
+        ):
+            self.task.save(clean=False)
+            self.execute(owner)
+        self.assertEqual(effects, [])
+        self.assertEqual(Task.objects.get(pk=self.task.pk).job_name, owner.name)
+
+    def test_save_reports_that_an_unreachable_broker_left_the_schedule_stale(self):
+        """A cron save that could not reach the broker must not report success silently."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        with patch.object(type(self.queue.connection), "zscan_iter", side_effect=RedisConnectionError("offline")):
+            self.task.save(clean=False)
+        self.assertFalse(self.task.schedule_updated)
+        self.task.save(clean=False)
+        self.assertTrue(self.task.schedule_updated)
+
+    def test_ambiguous_enqueue_is_adopted_on_next_tick(self):
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        from scheduler.helpers.queues import Queue
+
+        self.queue.delete_job(self.task.job_name)
+        original = Queue.create_and_enqueue_job
+
+        def enqueue(queue, *args, **kwargs):
+            original(queue, *args, **kwargs)
+            raise RedisConnectionError("reply lost after enqueue")
+
+        with patch.object(Queue, "create_and_enqueue_job", enqueue):
+            self.task.save(clean=False)
+        (owner,) = self.scheduled()
+        self.task.save(clean=False)
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.scheduled(), [owner])
+
+    def test_scheduler_rechecks_enabled_after_enumerating_tasks(self):
+        """A task disabled while the sweep is running is skipped, not rescheduled from a stale id."""
+        from scheduler.worker import scheduler
+
+        other = task_factory(TaskType.CRON)
+        owner = other.job_name
+        original = Task.reschedule_if_needed
+
+        def reschedule_if_needed(task):
+            if task.pk == self.task.pk:
+                Task.objects.filter(pk=other.pk).update(enabled=False)
+            return original(task)
+
+        with patch.object(Task, "reschedule_if_needed", reschedule_if_needed):
+            scheduler._reschedule_tasks()
+        other.refresh_from_db()
+        self.assertFalse(other.enabled)
+        self.assertEqual(other.job_name, owner)
+
+    def test_manual_payload_cannot_run_after_deletion_or_type_change(self):
+        manual = self.manual_job()
+        self.task.task_type = TaskType.ONCE
+        self.task.save(clean=False)
+        effects = []
+        with patch.object(Task, "callable_func", return_value=lambda: effects.append("executed")):
+            self.execute(manual)
+            self.task.delete()
+            self.execute(manual)
+        self.assertEqual(effects, [])
+
+    def test_running_once_job_keeps_outcome_after_conversion_to_cron(self):
+        self.task.task_type = TaskType.ONCE
+        self.task.save(clean=False)
+        job = self.job(self.task.job_name)
+        self.queue.scheduled_job_registry.delete(self.queue.connection, job.name)
+        job.prepare_for_execution("transition", self.queue.active_job_registry, self.queue.connection)
+        self.task.task_type = TaskType.CRON
+        self.task.save(clean=False)
+        owner = self.task.job_name
+        success_callback(job, self.queue.connection, None)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.successful_runs, 1)
+        self.assertEqual(self.task.job_name, owner)
+        self.assertEqual(self.scheduled(), [owner])
+
+    def test_reconcile_command_dry_run_preserves_duplicates_until_apply(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        duplicate = self.duplicate()
+        output = StringIO()
+        call_command("reconcile_scheduler", stdout=output)
+        self.assertIn("2 live recurring jobs", output.getvalue())
+        self.assertIn(duplicate.name, self.scheduled())
+        call_command("reconcile_scheduler", apply=True, stdout=StringIO())
+        self.assertEqual(self.scheduled(), [self.task.job_name])
+
+    def test_repeatable_recovers_when_worker_dies_after_dequeue(self):
+        task = task_factory(TaskType.REPEATABLE)
+        job = self.job(task.job_name)
+        self.queue.enqueue_job(job)
+        self.queue.queued_job_registry.delete(self.queue.connection, job.name)
+        with patch("django.utils.timezone.now", return_value=timezone.now() + timedelta(days=2)):
+            task.save(clean=False)
+        self.assertNotEqual(task.job_name, job.name)
+        self.assertIn(task.job_name, self.scheduled())
+
+    def test_slow_scheduler_still_recovers_a_lost_handoff(self):
+        from unittest.mock import PropertyMock
+
+        import time_machine
+        from fakeredis import FakeRedis, FakeServer
+
+        from scheduler.helpers.queues import Queue
+
+        # Advance the broker clock too, making premature marker expiry observable.
+        queue = Queue(FakeRedis(server=FakeServer()), "default")
+        with patch.object(Task, "rqueue", new_callable=PropertyMock, return_value=queue):
+            task = task_factory(TaskType.CRON, timeout=1)
+            job = JobModel.get(task.job_name, connection=queue.connection)
+            queue.enqueue_job(job)
+            queue.queued_job_registry.delete(queue.connection, job.name)
+            task.save(clean=False)
+            with time_machine.travel(timezone.now() + timedelta(seconds=300), tick=False):
+                task.save(clean=False)
+        self.assertNotEqual(task.job_name, job.name)
+
+    def test_replacing_or_clearing_an_orphan_owner_releases_its_marker(self):
+        from scheduler.redis_models.job import MISSING_REGISTRY_KEY_PREFIX
+
+        for change in ("queue", "disabled", "missing_hash"):
+            with self.subTest(change=change):
+                task = task_factory(TaskType.CRON)
+                job = self.job(task.job_name)
+                self.queue.enqueue_job(job)
+                self.queue.queued_job_registry.delete(self.queue.connection, job.name)
+                task.save(clean=False)
+                key = f"{MISSING_REGISTRY_KEY_PREFIX}{job.name}"
+                self.assertIsNotNone(self.queue.connection.get(key))
+                if change == "queue":
+                    task.queue = "test3"
+                elif change == "disabled":
+                    task.enabled = False
+                else:
+                    job.delete(self.queue.connection)
+                task.save(clean=False)
+                self.assertIsNone(self.queue.connection.get(key))
+
+
+class DefaultWriteRouter:
+    def db_for_write(self, model, **hints):
+        return "default"
+
+
+class SplitReadWriteRouter:
+    def db_for_read(self, model, **hints):
+        return "other"
+
+    def db_for_write(self, model, **hints):
+        return "default"
+
+
+class TestCronDatabaseIsolation(SchedulerBaseCase):
+    databases = {"default", "other"}
+
+    def test_admin_bulk_delete_uses_write_database(self):
+        task = task_factory(TaskType.CRON)
+        queue = task.rqueue
+        task_admin = TaskAdmin(Task, admin.site)
+        request = RequestFactory().post("/admin/scheduler/task/")
+
+        with self.settings(DATABASE_ROUTERS=[SplitReadWriteRouter()]):
+            task_admin.delete_queryset(request, Task.objects.filter(pk=task.pk))
+
+        self.assertFalse(Task.objects.using("default").filter(pk=task.pk).exists())
+        self.assertEqual(queue.scheduled_job_registry.all(queue.connection), [])
+
+    def test_same_task_id_in_another_database_keeps_both_owners(self):
+        first = task_factory(TaskType.CRON)
+        second = task_factory(TaskType.CRON, instance_only=True, id=first.pk)
+        second.save(using="other")
+        queue = first.rqueue
+        expected = {first.job_name, second.job_name}
+        self.assertEqual(set(queue.scheduled_job_registry.all(queue.connection)), expected)
+        first.save(clean=False)
+        second.save(clean=False)
+        self.assertEqual(set(queue.scheduled_job_registry.all(queue.connection)), expected)
+        second.enqueue_to_run()
+        (name,) = queue.queued_job_registry.all(queue.connection)
+        job = JobModel.get(name, connection=queue.connection)
+        queue.queued_job_registry.delete(queue.connection, name)
+        queue.run_sync(job)
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.successful_runs, 0)
+        self.assertEqual(second.successful_runs, 1)
+        second.delete(using="other")
+        self.assertEqual(queue.scheduled_job_registry.all(queue.connection), [first.job_name])
+
+    def test_explicit_database_is_preserved_when_router_prefers_default(self):
+        with self.settings(DATABASE_ROUTERS=[DefaultWriteRouter()]):
+            task = task_factory(TaskType.CRON, instance_only=True, id=20000)
+            task.save(using="other")
+            task.refresh_from_db(using="other")
+            owner = task.job_name
+            queue = task.rqueue
+            job = JobModel.get(owner, connection=queue.connection)
+            queue.scheduled_job_registry.delete(queue.connection, owner)
+            queue.run_sync(job)
+            task.refresh_from_db(using="other")
+            self.assertEqual(task.successful_runs, 1)
+            self.assertEqual(task.failed_runs, 0)
+            self.assertNotEqual(task.job_name, owner)
+            self.assertEqual(queue.scheduled_job_registry.all(queue.connection), [task.job_name])
+            self.assertFalse(Task.objects.using("default").exists())
+
+    def test_non_cron_creation_preserves_explicit_database_with_write_router(self):
+        for task_type in (TaskType.ONCE, TaskType.REPEATABLE):
+            with self.subTest(task_type=task_type), self.settings(DATABASE_ROUTERS=[DefaultWriteRouter()]):
+                task = task_factory(task_type, instance_only=True)
+                task.save(using="other")
+                task.refresh_from_db(using="other")
+                job = JobModel.get(task.job_name, connection=task.rqueue.connection)
+                self.assertEqual(job.meta["scheduler_task_database"], "other")
+                self.assertFalse(Task.objects.using("default").exists())
+
+    def test_non_cron_completion_preserves_database_with_write_router(self):
+        for task_type in (TaskType.ONCE, TaskType.REPEATABLE):
+            with self.subTest(task_type=task_type):
+                first = task_factory(task_type)
+                second = task_factory(task_type, instance_only=True, id=first.pk)
+                second.save(using="other")
+                original = Task.objects.using("default").values().get(pk=first.pk)
+                queue = second.rqueue
+                job = JobModel.get(second.job_name, connection=queue.connection)
+                queue.scheduled_job_registry.delete(queue.connection, job.name)
+                with (
+                    self.settings(DATABASE_ROUTERS=[DefaultWriteRouter()]),
+                    patch("django.utils.timezone.now", return_value=second.scheduled_time + timedelta(seconds=1)),
+                ):
+                    queue.run_sync(job)
+                self.assertEqual(Task.objects.using("default").values().get(pk=first.pk), original)
+                second.refresh_from_db(using="other")
+                self.assertEqual(second.successful_runs, 1)
+                self.assertEqual(second.failed_runs, 0)
+                if task_type == TaskType.ONCE:
+                    self.assertIsNone(second.job_name)
+                else:
+                    self.assertNotEqual(second.job_name, job.name)
+                    successor = JobModel.get(second.job_name, connection=queue.connection)
+                    self.assertEqual(successor.meta["scheduler_task_database"], "other")
+                    self.assertIn(second.job_name, queue.scheduled_job_registry.all(queue.connection))
+
+    def test_same_id_and_timestamp_preserve_both_database_jobs(self):
+        with patch("django.utils.timezone.now", return_value=timezone.now()):
+            first = task_factory(TaskType.CRON)
+            second = task_factory(TaskType.CRON, instance_only=True, id=first.pk)
+            second.save(using="other")
+        queue = first.rqueue
+        self.assertCountEqual(queue.scheduled_job_registry.all(queue.connection), [first.job_name, second.job_name])
+        for task, alias in ((first, "default"), (second, "other")):
+            job = JobModel.get(task.job_name, connection=queue.connection)
+            self.assertEqual(job.meta["scheduler_task_database"], alias)
+            queue.scheduled_job_registry.delete(queue.connection, job.name)
+            queue.run_sync(job)
+            task.refresh_from_db(using=alias)
+            self.assertEqual(task.successful_runs, 1)
+            self.assertNotEqual(task.job_name, job.name)
+        self.assertCountEqual(queue.scheduled_job_registry.all(queue.connection), [first.job_name, second.job_name])
+
+    def test_manual_enqueue_preserves_selected_database_with_write_router(self):
+        first = task_factory(TaskType.CRON)
+        second = task_factory(TaskType.CRON, instance_only=True, id=first.pk)
+        second.save(using="other")
+        owners = [first.job_name, second.job_name]
+        queue = second.rqueue
+        with self.settings(DATABASE_ROUTERS=[DefaultWriteRouter()]):
+            second.enqueue_to_run()
+            [name] = queue.queued_job_registry.all(queue.connection)
+            job = JobModel.get(name, connection=queue.connection)
+            self.assertEqual(job.meta["scheduler_task_database"], "other")
+            self.assertTrue(job.meta["scheduler_manual_run"])
+            queue.queued_job_registry.delete(queue.connection, name)
+            queue.run_sync(job)
+        first.refresh_from_db()
+        second.refresh_from_db(using="other")
+        self.assertEqual(first.successful_runs, 0)
+        self.assertEqual(second.successful_runs, 1)
+        self.assertEqual([first.job_name, second.job_name], owners)
+        self.assertCountEqual(queue.scheduled_job_registry.all(queue.connection), owners)
+
+    def test_unschedule_preserves_selected_database_with_write_router(self):
+        first = task_factory(TaskType.CRON)
+        second = task_factory(TaskType.CRON, instance_only=True, id=first.pk)
+        second.save(using="other")
+        owner = first.job_name
+        with self.settings(DATABASE_ROUTERS=[DefaultWriteRouter()]):
+            second.unschedule(enabled=False)
+        first.refresh_from_db()
+        second.refresh_from_db(using="other")
+        self.assertTrue(first.enabled)
+        self.assertEqual(first.job_name, owner)
+        self.assertFalse(second.enabled)
+        self.assertIsNone(second.job_name)
+        self.assertEqual(first.rqueue.scheduled_job_registry.all(first.rqueue.connection), [owner])

--- a/scheduler/tests/test_task_types/test_cron_scheduler_race.py
+++ b/scheduler/tests/test_task_types/test_cron_scheduler_race.py
@@ -1,0 +1,110 @@
+"""Reproduce automatic scheduler/completion races with PostgreSQL and a broker."""
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from threading import Event
+from unittest import skipUnless
+from unittest.mock import patch
+
+from django.db import close_old_connections, connection
+from django.test import TransactionTestCase
+
+from scheduler.helpers.queues import Queue, get_queue
+from scheduler.models import TaskType
+from scheduler.redis_models import JobModel, JobStatus
+from scheduler.tests import conf  # noqa: F401
+from scheduler.tests.testtools import task_factory
+from scheduler.worker.scheduler import _reschedule_tasks
+
+
+@skipUnless(connection.vendor == "postgresql", "Requires PostgreSQL transaction isolation and row locks")
+class TestCronSchedulerRace(TransactionTestCase):
+    def setUp(self):
+        self.queue = get_queue("default")
+        if port := os.getenv("BROKER_PORT"):
+            self.assertEqual(
+                self.queue.connection.connection_pool.connection_kwargs["port"],
+                int(port),
+                "Test configuration ignored BROKER_PORT; refusing to flush Redis",
+            )
+        self.queue.connection.flushall()
+        self.task = task_factory(TaskType.CRON)
+        job = JobModel.get(self.task.job_name, connection=self.queue.connection)
+        self.queue.enqueue_job(job)
+        self.job, _ = Queue.dequeue_any([self.queue], timeout=None, connection=self.queue.connection)
+        self.assertIsNotNone(self.job)
+
+    @contextmanager
+    def paused_sweep(self):
+        """Pause after the sweep's first real Task SELECT, keeping its snapshot."""
+        snapshot_read = Event()
+        resume = Event()
+
+        def pause_after_read(execute, sql, params, many, context):
+            result = execute(sql, params, many, context)
+            if not snapshot_read.is_set() and sql.startswith("SELECT") and self.task._meta.db_table in sql:
+                snapshot_read.set()
+                if not resume.wait(timeout=10):
+                    raise TimeoutError("Completion did not release the scheduler sweep")
+            return result
+
+        def sweep():
+            close_old_connections()
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET lock_timeout = '10s'")
+                with connection.execute_wrapper(pause_after_read):
+                    _reschedule_tasks()
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = None
+
+            def start_sweep():
+                nonlocal future
+                self.assertIsNone(future, "Only one automatic sweep is needed")
+                future = pool.submit(sweep)
+                self.assertTrue(snapshot_read.wait(timeout=10), "Scheduler did not read its task snapshot")
+
+            try:
+                yield start_sweep
+            finally:
+                resume.set()
+                if future is not None:
+                    future.result(timeout=20)
+
+    def assert_one_successor(self):
+        self.task.refresh_from_db()
+        scheduled = self.queue.scheduled_job_registry.all(self.queue.connection)
+        self.assertEqual(self.job.status, JobStatus.FINISHED)
+        self.assertEqual(
+            {"scheduled_jobs": len(scheduled), "successful_runs": self.task.successful_runs},
+            {"scheduled_jobs": 1, "successful_runs": 1},
+        )
+        self.assertEqual(scheduled, [self.task.job_name])
+        self.assertNotEqual(self.task.job_name, self.job.name)
+        self.assertIsNotNone(self.task.last_successful_run)
+        self.assertEqual(self.task.failed_runs, 0)
+        self.assertEqual(self.queue.queued_job_registry.all(self.queue.connection), [])
+        self.assertEqual(self.queue.active_job_registry.all(self.queue.connection), [])
+
+    def test_sweep_read_before_completion_preserves_successor_and_counter(self):
+        with self.paused_sweep() as start_sweep:
+            start_sweep()
+            self.queue.run_sync(self.job)
+        self.assert_one_successor()
+
+    def test_sweep_read_during_successor_creation_keeps_one_chain(self):
+        create_job = Queue.create_and_enqueue_job
+        with self.paused_sweep() as start_sweep:
+
+            def create_after_sweep_read(queue, *args, **kwargs):
+                # The old callback has published job_name=NULL by this point.
+                start_sweep()
+                return create_job(queue, *args, **kwargs)
+
+            with patch.object(Queue, "create_and_enqueue_job", create_after_sweep_read):
+                self.queue.run_sync(self.job)
+        self.assert_one_successor()

--- a/scheduler/tests/test_worker/test_db_connections.py
+++ b/scheduler/tests/test_worker/test_db_connections.py
@@ -17,7 +17,7 @@ Two things shape how these tests are written:
 import threading
 from unittest import mock
 
-from django.db import connections
+from django.db import DatabaseError, connections
 from django.test import TransactionTestCase
 
 from scheduler.helpers.callback import Callback
@@ -138,11 +138,12 @@ class TestMaintenanceThatRunsAFailureCallback(WorkerDbConnectionTestCase):
         task = task_factory(TaskType.ONCE)
         self._enqueue_an_abandoned_job_for(task)
         worker = self._worker("test-maintenance-db-raises")
+        connections["default"].close()
 
         with (
             self._watch_closes(),
-            mock.patch("scheduler.models.task.mail_admins", side_effect=ValueError("mail server down")),
-            self.assertRaises(ValueError),
+            mock.patch("django.db.models.query.QuerySet.update", side_effect=DatabaseError("completion update failed")),
+            self.assertRaisesRegex(DatabaseError, "completion update failed"),
         ):
             worker.run_maintenance_tasks()
 

--- a/scheduler/types/broker_types.py
+++ b/scheduler/types/broker_types.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from .settings_types import Broker
 
+BrokerErrorTypes = (redis.exceptions.RedisError, getattr(valkey.exceptions, "ValkeyError", redis.exceptions.RedisError))
 ConnectionErrorTypes = (redis.ConnectionError, valkey.ConnectionError)
 ResponseErrorTypes = (redis.ResponseError, valkey.ResponseError)
 TimeoutErrorTypes = (redis.TimeoutError, valkey.TimeoutError)

--- a/scheduler/worker/scheduler.py
+++ b/scheduler/worker/scheduler.py
@@ -8,6 +8,7 @@ from logging import DEBUG, INFO
 from threading import Thread
 
 import django
+from django.db import router, transaction
 
 from scheduler.helpers.queues import Queue, get_queue
 from scheduler.helpers.queues.getters import get_queue_connection
@@ -27,12 +28,15 @@ def _reschedule_tasks() -> None:
     # Read each task immediately before scheduling it rather than materializing them all up front: a completion
     # callback can store a new job name for a task while this loop is running, and scheduling from the instance read
     # earlier would add a second recurring chain next to the successor the callback just created.
-    for task_id in Task.objects.filter(enabled=True).values_list("id", flat=True):
-        task = Task.objects.filter(id=task_id, enabled=True).first()
-        if task is None:  # disabled or deleted since the ids were read
-            continue
-        logger.debug(f"Rescheduling {task!s}")
-        task.reschedule_if_needed()
+    using = router.db_for_write(Task)
+    ids = list(Task.objects.using(using).filter(enabled=True).order_by("pk").values_list("pk", flat=True))
+    for task_id in ids:
+        with transaction.atomic(using=using):
+            task = Task.objects.using(using).select_for_update().filter(pk=task_id, enabled=True).first()
+            if task is None:  # disabled or deleted since the ids were read
+                continue
+            logger.debug(f"Rescheduling {task!s}")
+            task.reschedule_if_needed()
 
 
 class WorkerScheduler:

--- a/testproject/testproject/postgres_settings.py
+++ b/testproject/testproject/postgres_settings.py
@@ -1,0 +1,17 @@
+"""Optional PostgreSQL configuration for the concurrent cron ownership tests."""
+import os
+
+from .settings import *  # noqa: F403
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.getenv("PGDATABASE", "scheduler"),
+        "USER": os.getenv("PGUSER", "scheduler"),
+        "PASSWORD": os.getenv("PGPASSWORD", "scheduler-test"),
+        "HOST": os.getenv("PGHOST", "127.0.0.1"),
+        "PORT": os.getenv("PGPORT", "5432"),
+    }
+}
+USE_TZ = True
+DATABASES["other"] = {**DATABASES["default"], "NAME": DATABASES["default"]["NAME"] + "_other"}

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -148,3 +148,9 @@ LOGGING = {
         },
     },
 }
+
+# A second database exercises task IDs that overlap across database aliases.
+DATABASES["other"] = {
+    "ENGINE": "django.db.backends.sqlite3",
+    "NAME": os.path.join(BASE_DIR, "other.sqlite3"),
+}


### PR DESCRIPTION
Normal scheduler sweeps can race with cron completion and create multiple persistent recurring chains. Manual **Enqueue now** executions and stale task saves can create the same result.

This change:

- serializes recurring ownership changes with fresh, row-locked task state;
- separates manual executions from the recurring owner;
- adopts existing broker jobs and retires duplicate waiting jobs;
- preserves execution counters during stale saves and concurrent callbacks;
- keeps admin bulk deletion atomic with schedule removal, including routed databases; and
- adds `reconcile_scheduler` to inspect and repair existing schedules.

It includes PostgreSQL concurrency coverage for scheduler/completion races, admin deletion, callback failures, and database routing.

Validation:

- 413 scheduler tests passed with real Redis (6 PostgreSQL-only tests skipped).
- 53 focused PostgreSQL and real Redis tests passed.
- Pre-commit checks and the strict documentation build passed.

