### PR TITLE
chore: modernize code for the minimum supported django

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,12 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.32.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "5.0"]
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.25.3
     hooks:

--- a/scheduler/apps.py
+++ b/scheduler/apps.py
@@ -6,6 +6,3 @@ class SchedulerConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
     name = "scheduler"
     verbose_name = _("Tasks Scheduler")
-
-    def ready(self):
-        pass

--- a/scheduler/models/task.py
+++ b/scheduler/models/task.py
@@ -116,7 +116,7 @@ class Task(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     name = models.CharField(_("name"), max_length=128, unique=True, help_text=_("Name of the job"))
-    task_type = models.CharField(_("Task type"), max_length=32, choices=TaskType.choices, default=TaskType.ONCE)
+    task_type = models.CharField(_("Task type"), max_length=32, choices=TaskType, default=TaskType.ONCE)
     callable = models.CharField(_("callable"), max_length=2048)
     callable_args = GenericRelation(TaskArg, related_query_name="args")
     callable_kwargs = GenericRelation(TaskKwarg, related_query_name="kwargs")

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -14,7 +14,7 @@ SCHEDULER_QUEUES = {
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "h0_r$4#4@hgdxy_r0*n8+$(wf0&ie9&4-=(d394n!bo=9rt+85"
@@ -76,7 +76,7 @@ TEMPLATES = [
 WSGI_APPLICATION = "testproject.wsgi.application"
 
 # Database
-# https://docs.djangoproject.com/en/1.9/ref/settings/#databases
+# https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
 DATABASES = {
     "default": {
@@ -86,7 +86,7 @@ DATABASES = {
 }
 
 # Password validation
-# https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators
+# https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -104,7 +104,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.9/topics/i18n/
+# https://docs.djangoproject.com/en/5.0/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
 
@@ -112,12 +112,10 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = False
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.9/howto/static-files/
+# https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = "/static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,17 +1,18 @@
-"""testproject URL Configuration
+"""
+URL configuration for testproject.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.9/topics/http/urls/
+    https://docs.djangoproject.com/en/5.0/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the `include()` function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
 from django.contrib import admin

--- a/testproject/testproject/wsgi.py
+++ b/testproject/testproject/wsgi.py
@@ -1,10 +1,10 @@
 """
-WSGI config for testproject project.
+WSGI config for testproject.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
 """
 
 import os


### PR DESCRIPTION
## Description

The `django-tasks-scheduler` currently supports Django `5.0.0` and above.

- Remove stale references to previous Django versions.
- Add the `django-upgrade` pre-commit hook, See: https://github.com/adamchainz/django-upgrade
- Clean up unnecessary code.