### PR TITLE
fix(task): don't schedule a duplicate successor from a stale scheduler-loop task

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 
 - Fix **Requeue** on the job detail page failing with `Action requeue is not supported`; requeuing a failed job from
   the jobs list now also removes it from the failed jobs registry #415
+- Fix the scheduler loop scheduling a duplicate successor for a task whose job finished while the loop was handling
+  it, and rolling back a repeatable task's schedule #418
 
 ## v4.3.0 🌈
 

--- a/scheduler/models/task.py
+++ b/scheduler/models/task.py
@@ -410,8 +410,10 @@ class Task(models.Model):
 
         :returns: True if a job was scheduled, False otherwise.
         """
+        self._refresh_run_state()
         scheduled = self._schedule()
-        self.save(schedule_job=False, clean=False, update_fields=_SCHEDULING_FIELDS)
+        if scheduled:
+            self.save(schedule_job=False, clean=False, update_fields=_SCHEDULING_FIELDS)
         return scheduled
 
     def delete(self, **kwargs: Any) -> None:

--- a/scheduler/tests/test_task_types/test_duplicate_chains.py
+++ b/scheduler/tests/test_task_types/test_duplicate_chains.py
@@ -1,4 +1,8 @@
-"""Regression tests for #412: manual runs and stale saves must not start a second recurring chain."""
+"""Regression tests for #412 and #418: manual runs and stale saves must not start a second recurring chain."""
+
+from datetime import timedelta
+
+from django.utils import timezone
 
 from scheduler.helpers.queues import get_queue
 from scheduler.models import Task, TaskType
@@ -130,6 +134,38 @@ class TestNoDuplicateChains(SchedulerBaseCase):
         self.assertTrue(reloaded.reschedule_if_needed())
 
         self.assertEqual({reloaded.job_name}, self.scheduled_job_names())
+
+    def test_stale_reschedule_if_needed_does_not_add_a_chain(self):
+        """The scheduler loop read the task, then its job finished and the callback scheduled the successor."""
+        task = task_factory(TaskType.CRON)
+        stale = Task.objects.get(id=task.id)
+
+        self.enqueue_scheduled_job(stale.job_name)
+        _run_pending_jobs()
+        successor = Task.objects.get(id=task.id).job_name
+
+        self.assertFalse(stale.reschedule_if_needed())
+
+        self.assertEqual({successor}, self.scheduled_job_names())
+        self.assertEqual(successor, Task.objects.get(id=task.id).job_name)
+
+    def test_stale_reschedule_if_needed_does_not_roll_back_the_schedule(self):
+        task = task_factory(TaskType.REPEATABLE, repeat=5)
+        # Let the scheduled time pass, so the callback advances the schedule and spends a repeat.
+        Task.objects.filter(id=task.id).update(scheduled_time=timezone.now() - timedelta(minutes=1))
+        stale = Task.objects.get(id=task.id)
+
+        self.enqueue_scheduled_job(stale.job_name)
+        _run_pending_jobs()
+        advanced = Task.objects.get(id=task.id)
+        self.assertEqual(4, advanced.repeat)
+
+        self.assertFalse(stale.reschedule_if_needed())
+
+        reloaded = Task.objects.get(id=task.id)
+        self.assertEqual({advanced.job_name}, self.scheduled_job_names())
+        self.assertEqual(advanced.scheduled_time, reloaded.scheduled_time)
+        self.assertEqual(4, reloaded.repeat)
 
     def test_disabled_task_run_clears_the_job_name(self):
         task = task_factory(TaskType.CRON)


### PR DESCRIPTION
## Summary

Fixes #418, supersedes #419 (keeps @mmcardle's fix commit, replaces its test).

The scheduler loop reads a task and then calls `reschedule_if_needed()` on it. If the task's job finishes in between, the completion callback stores the successor's name, but the loop still holds the old one: `is_scheduled()` finds that job gone, clears `job_name` over the successor's, and `_schedule()` enqueues a second successor. The two chains then keep each other alive.

## Fix

`reschedule_if_needed()`:
- re-reads the run state (`job_name`, counters) right before checking whether the task is scheduled, so it sees the successor the callback just stored;
- writes back the scheduling fields only when it actually scheduled a job. Otherwise a stale instance restores the `scheduled_time`/`repeat` the callback had already advanced.

## Tests

Two single-threaded tests in `test_duplicate_chains.py` reproduce the interleaving directly: read the task the way the loop does, run its job to completion, then call `reschedule_if_needed()` on the stale instance.

- `test_stale_reschedule_if_needed_does_not_add_a_chain`: fails without the refresh (a second successor is scheduled).
- `test_stale_reschedule_if_needed_does_not_roll_back_the_schedule`: fails without the save guard (the repeatable task's `scheduled_time` goes back an hour).

No threads, patched `QuerySet` methods, `TransactionTestCase` or timeouts, and nothing SQLite-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1HcEJmPpGYMjvesFYCtA6
